### PR TITLE
Fixes: OPENSTACK-61

### DIFF
--- a/unsupported/ve/four_member_dsc/f5_onboard_ve_four_way_cluster_3_networks.yaml
+++ b/unsupported/ve/four_member_dsc/f5_onboard_ve_four_way_cluster_3_networks.yaml
@@ -1,3 +1,17 @@
+# Copyright 2015 F5 Networks
+#
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##    http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
 heat_template_version: 2014-10-16
 
 description: >
@@ -947,8 +961,10 @@ resources:
                 unset https_proxy
             fi
             
-            # Path to download local copy of cluster.py
+            # TODO: These wgets are just patches to cluster.py and cluster_generic.py until we have redeployable packages of the refactored odk/onboard/common code.
             wget --no-check-certificate -O /usr/lib/python2.7/dist-packages/f5/bigip/interfaces/cluster.py https://bldr-git.int.lineratesystems.com/breaux/f5-common-python-local/raw/develop_breaux_four-way-cluster/f5/bigip/interfaces/cluster.py
+
+            wget --no-check-certificate -O /usr/lib/python2.7/dist-packages/f5/onboard/bigip/cluster_generic.py https://bldr-git.int.lineratesystems.com/breaux/f5-openstack-onboard-local/raw/onboard_breaux_no_failover/f5_onboarding/cluster_generic.py
 
             # cluster VEs
             # cluster tenant stacked BIG-IPS

--- a/unsupported/ve/four_member_dsc/f5_onboard_ve_four_way_cluster_4_networks.yaml
+++ b/unsupported/ve/four_member_dsc/f5_onboard_ve_four_way_cluster_4_networks.yaml
@@ -1,3 +1,17 @@
+# Copyright 2015 F5 Networks
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #    http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+
 heat_template_version: 2014-10-16
 
 description: >
@@ -973,10 +987,11 @@ resources:
                 unset https_proxy
             fi
             
-            # Path to download local copy of cluster.py
+            # TODO: These wgets are just patches to cluster.py and cluster_generic.py until we have redeployable packages of the refactored odk/onboard/common code.
             wget --no-check-certificate -O /usr/lib/python2.7/dist-packages/f5/bigip/interfaces/cluster.py https://bldr-git.int.lineratesystems.com/breaux/f5-common-python-local/raw/develop_breaux_four-way-cluster/f5/bigip/interfaces/cluster.py
 
             wget --no-check-certificate -O /usr/lib/python2.7/dist-packages/f5/onboard/bigip/cluster_generic.py https://bldr-git.int.lineratesystems.com/breaux/f5-openstack-onboard-local/raw/onboard_breaux_no_failover/f5_onboarding/cluster_generic.py
+
             # cluster VEs
             # cluster tenant stacked BIG-IPS
             source f5-onboard-utils

--- a/unsupported/ve/four_member_dsc/f5_onboard_ve_four_way_cluster_5_networks.yaml
+++ b/unsupported/ve/four_member_dsc/f5_onboard_ve_four_way_cluster_5_networks.yaml
@@ -1,3 +1,17 @@
+# Copyright 2015 F5 Networks
+# #
+# # Licensed under the Apache License, Version 2.0 (the "License");
+# # you may not use this file except in compliance with the License.
+# # You may obtain a copy of the License at
+# #
+# #    http://www.apache.org/licenses/LICENSE-2.0
+# #
+# # Unless required by applicable law or agreed to in writing, software
+# # distributed under the License is distributed on an "AS IS" BASIS,
+# # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# # See the License for the specific language governing permissions and
+# # limitations under the License.
+
 heat_template_version: 2014-10-16
 
 description: >
@@ -1085,10 +1099,11 @@ resources:
                 unset https_proxy
             fi
             
-            # Path to download local copy of cluster.py
+            # TODO: These wgets are just patches to cluster.py and cluster_generic.py until we have redeployable packages of the refactored odk/onboard/common code.
             wget --no-check-certificate -O /usr/lib/python2.7/dist-packages/f5/bigip/interfaces/cluster.py https://bldr-git.int.lineratesystems.com/breaux/f5-common-python-local/raw/develop_breaux_four-way-cluster/f5/bigip/interfaces/cluster.py
 
             wget --no-check-certificate -O /usr/lib/python2.7/dist-packages/f5/onboard/bigip/cluster_generic.py https://bldr-git.int.lineratesystems.com/breaux/f5-openstack-onboard-local/raw/onboard_breaux_no_failover/f5_onboarding/cluster_generic.py
+
             # cluster VEs
             # cluster tenant stacked BIG-IPS
             source f5-onboard-utils


### PR DESCRIPTION
#### What's this change address?

Heat templates for 4-way DSC VE
#### Where should the reviewer start?

Start at the f5_onboard_ve_four_way_cluster_3_networks.yaml and move up in interfaces from there. The only major changes across these files are the addition of network (data) interfaces for the VEs being provisioned.
#### Any background context?

Analysis: Introducing more interfaces (3-5) for these templates. Going
past 5 interfaces causes a nova user-data issue, where the user-data
dump is too big for the instance. This means the bash script has become
too large for openstack to handle. It has not been determined if this is
a limit we have control over.

These templates will not work until new packages are generate with
f5-common-python and f5-openstack-onboard repos, as changes have been
made to cluster.py and cluster_generic.py to make the four-way cluster
work. The templates were tested manually for all interfaces, by patching the
files named above with fixed versions to support four-way clusters.
