### PR TITLE
Document each group of templates in the unsupported folder

### DIFF
--- a/unsupported/learning_stacks/learning_stacks.rst
+++ b/unsupported/learning_stacks/learning_stacks.rst
@@ -1,0 +1,7 @@
+Learning Stacks
+===============
+If you are just starting out with orchestration in OpenStack, this is a good place to get an idea of how a Heat stack manages resources. The stack deploys a client, device-under-test, and a server and creates nearly all network plumbing necessary with the exception of the external network.
+
+Multi-Homing
+------------
+Three Ubuntu 14.04 instances are created. Each instance connects to a data network, which is associated with the floating IP for that instance. In addition, the client connects to the DUT via the client_test_network. The server connects to the DUT via the server_test_network. All instances in this stack are multi-homed. This is important to know because default Ubuntu cloud images for 14.04 do not support multiple nics out of the box. You can solve these problems by referring to this `cloudify blog <http://getcloudify.org/2015/05/18/openstack-neutron-nova-cloud-vm-networking-network-automation-orchestration.html>` regarding a multi-homed instance in OpenStack. We have solved this problem by using `ifplugd <http://0pointer.de/lennart/projects/ifplugd/>`, a service baked into the image that waits for any and all interfaces to be hotplugged. Cloud-init creates the port on the OpenStack side for this instance to connect to the additional networks, and it also configures the ethernet devices to be available on the instance. It does not however, bring up the additional interfaces. That's the job of ifplugd or your startup script and whatever you choose to use.

--- a/unsupported/ve/common/common_templates.rst
+++ b/unsupported/ve/common/common_templates.rst
@@ -1,0 +1,24 @@
+Common Template Resources
+=========================
+
+Description
+-----------
+The templates in this directory are often used by other templates to compose a customized stack. For example, the security group templates (such as bigip_data_security_group.yaml) here are pulled in by the standalone templates in the following manner:
+
+    resources:
+      bigip_data_security_group:
+        type: https://raw.githubusercontent.com/F5Networks/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_data_security_group.yaml
+
+And once brought into the parent template in this manner, they can be referred to in the sub-template like so:
+
+    resources:
+      network_1_port:
+        type: OS::Neutron::Port
+        properties:
+          network: {get_param: network_1 }
+          security_groups:
+            - bigip_data_security_group
+
+This means that the sub-templates may have parameter and resource dependecies that are given to them via the calling template. When in doubt about what needs to be imported to make a sub-template work, you can review a simple parent template such as those in ../standalone/. This is called template composition, and if you'd like more information on the process go to `Openstack's documentation <http://docs.openstack.org/developer/heat/template_guide/composition.html>`.
+
+The templates here named 'f5_ve_standalone_X_nic.yaml' are the ones described the OS::Nova::Instance for creating a single VE resource. The variations are only among the number of data interfaces that instance will have. Do not modify these templates unless you know what you are doing.

--- a/unsupported/ve/images/images.rst
+++ b/unsupported/ve/images/images.rst
@@ -1,0 +1,8 @@
+Generating OpenStack Ready VE Images
+====================================
+
+Description
+-----------
+The templates within this directory launch a Heat stack to prepare a VE image for use in OpenStack. The sync_image.yaml template launches an Ubuntu onboarding server that downloads an F5 BigIP VE qcow image, extracts it, if necessary, and patches it. Note, the URL given as the location for that F5 BigIP VE qcow image must be publicly accessible as for now. Once the image is patched, it is uploaded into the OpenStack Glance service you provided as inputs to the Heat template.
+
+Note: the templates currently are pulling an Ubuntu image from ubuntu.com, but you could easily replace that with an Ubuntu that already exists in your stack. After the image is uploaded into Glance, the stack then deletes itself. Please do not modify the 'user_data' script in the 'onboard_instance' resource unless you are certain what you are doing. The script is downloading, extracting, patching, and uploading the F5 image you specified as an input.

--- a/unsupported/ve/standalone/standalone.rst
+++ b/unsupported/ve/standalone/standalone.rst
@@ -1,0 +1,6 @@
+VE Standalone Templates
+=======================
+
+Description
+-----------
+The templates in this directory are those that deploy a single VE instance with variations only upon the number of data interfaces desired. These templates are composed of templates in the ../common/ directory such as the security groups and the OS::Nova::Server resources for the VE itself. Refer to those templates if you'd like to get a better idea of how template composition is done in Heat. Note that the license key is required as an input parameter to boot up a licensed VE. The license itself must be applicable for the modules you wish to have provisioned on the VE. The outputs of these templates give you a programmatic way to retrieve details about the VE launched by this stack.

--- a/unsupported/ve/ve_templates.rst
+++ b/unsupported/ve/ve_templates.rst
@@ -1,0 +1,8 @@
+VE Templates
+============
+
+Description
+-----------
+The templates within this directory launch and/or prepare BigIP Virtual Editions(VE). To launch a VE, one must use an OpenStack-Ready VE image. In the directory 'images' here, there are templates to do just that. This operation is done via a heat stack with an onboarding server. For more details, see the documentation within that directory.
+
+The other directories here contain templates to launch different configurations of one or more VEs. There are templates to launch a six-armed VE (that is, six data interfaces) and other for a two-armed deployment. The input paramaters of each should be enough of to customize to your needs.


### PR DESCRIPTION
Issues: Fixes: #26

Problem: Documentation is needed for each directory of templates with a
common purpose.

Analysis: Dropped rst files in each directory to describe the templates.
Next to be done are topologies and an update of the onboarding template
documentation.

Tests: