### PR TITLE
Moving heat templates for f5-openstack-heat-plugins to this repo

### DIFF
--- a/unsupported/f5_plugins/deploy_composite_iapp.yaml
+++ b/unsupported/f5_plugins/deploy_composite_iapp.yaml
@@ -1,0 +1,121 @@
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+heat_template_version: 2015-04-30
+
+description: Deploy composite iapp template and service
+
+parameters:
+  ve_instance1:
+    type: string
+    label: IP of Second VE Instance
+    default: 10.190.6.4
+  bigip_un:
+    type: string
+    label: Username of BigIP Login
+    default: admin
+  bigip_pw:
+    type: string
+    label: Password of BigIP Login
+    hidden: True
+  iapp_template_name:
+    type: string
+    label: Name of iApp Template
+    default: iapp_template_resource
+  iapp_service_name:
+    type: string
+    label: Name of iApp Service
+    default: iapp_service_resource
+
+parameter_groups:
+  - label: VE Parameters
+    parameters:
+      - ve_instance1
+      - bigip_un
+      - bigip_pw
+  - label: iApp Settings
+    parameters:
+      - iapp_template_name
+      - iapp_service_name
+
+resources:
+  bigip1:
+    type: F5::BigIP::Device
+    properties:
+      ip: { get_param: ve_instance1 }
+      username: { get_param: bigip_un }
+      password: { get_param: bigip_pw }
+  iapp_service:
+    type: F5::Sys::iAppService
+    depends_on: iapp_template
+    properties:
+      name: { get_param: iapp_service_name }
+      bigip_server: { get_resource: bigip1 }
+      partition: { get_resource: partition }
+      template_name: { get_param: iapp_template_name }
+  partition:
+    type: F5::Sys::Partition
+    depends_on: bigip1
+    properties:
+      name: Common
+      bigip_server: { get_resource: bigip1 }
+  iapp_template:
+    type: F5::Sys::iAppCompositeTemplate
+    depends_on: bigip1
+    properties:
+      name: { get_param: iapp_template_name }
+      bigip_server: { get_resource: bigip1 }
+      partition: { get_resource: partition }
+      requires_modules: [ ltm ]
+      implementation: |
+        #TMSH-VERSION: 11.6.0
+        iapp::template start
+        tmsh::create {
+          ltm pool http_pool
+          description "A pool of http servers"
+          load-balancing-mode least-connections-node
+          members replace-all-with {
+              129.0.0.1:8000 {
+                  address 129.0.0.1
+              }
+          }
+        }
+        tmsh::create {
+           ltm virtual http_vs
+           destination 10.15.15.30:80
+           ip-protocol tcp
+           mask 255.255.255.255
+           pool http_pool
+           profiles replace-all-with {
+               http { }
+               tcp { }
+           }
+           source 0.0.0.0/0
+           translate-address enabled
+           translate-port enabled
+        }
+        tmsh::create {
+           ltm virtual-address 10.4.4.115
+           address 10.4.4.115
+           arp enabled
+           icmp-echo enabled
+           mask 255.255.255.255
+           traffic-group traffic-group-1
+        }
+        iapp::template stop
+      presentation: |
+        section say_hello {
+          message intro "This template deploys a virtual server and a pool with several members."
+        }

--- a/unsupported/f5_plugins/deploy_composite_iapp_with_get_file_answers.yaml
+++ b/unsupported/f5_plugins/deploy_composite_iapp_with_get_file_answers.yaml
@@ -1,0 +1,229 @@
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+#
+
+heat_template_version: 2015-04-30
+
+description: Deploy iapp template and service using the get_file function to retrieve iapp service answers
+
+parameters:
+  iapp_template_name:
+    type: string
+    label: iApp Template Name
+    default: iapp_test_template
+  iapp_service_name:
+    type: string
+    label: iApp Service Name
+    default: iapp_test_service
+  ve_instance:
+    type: string
+    label: VE Instance IP
+    description: IP of existing VE
+  bigip_un:
+    type: string
+    label: BigIP Login Username
+    default: admin
+  bigip_pw:
+    type: string
+    label: BigIP Login Password
+    hidden: true
+parameter_groups:
+  - label: VE Parameters
+    parameters:
+      - ve_instance
+      - bigip_un
+      - bigip_pw
+  - label: Pool Parameters
+    parameters:
+      - iapp_template_name
+      - iapp_service_name
+resources:
+  bigip_rsrc:
+    type: F5::BigIP::Device
+    properties:
+      ip: { get_param: ve_instance }
+      username: { get_param: bigip_un }
+      password: { get_param: bigip_pw }
+  partition:
+    type: F5::Sys::Partition
+    depends_on: bigip_rsrc
+    properties:
+      name: Common
+      bigip_server: { get_resource: bigip_rsrc }
+  iapp_service:
+    type: F5::Sys::iAppService
+    depends_on: [iapp_template, partition]
+    properties:
+      name: { get_param: iapp_service_name }
+      bigip_server: { get_resource: bigip_rsrc }
+      partition: { get_resource: partition }
+      template_name: { get_param: iapp_template_name }
+      lists:
+        get_file: iapp_answers/lab_1_list.json
+      variables: |
+        [
+            {
+              "name": "some_variables__drop_down",
+              "encrypted": "no",
+              "value": "choice 2"
+            },
+            {
+              "name": "some_variables__more_input",
+              "encrypted": "no",
+              "value": "Yes"
+            },
+            {
+              "name": "some_variables__string_input_one",
+              "encrypted": "no",
+              "value": "testing"
+            },
+            {
+              "name": "some_variables__string_input_two",
+              "encrypted": "no",
+              "value": "Hello"
+            }
+          ]
+      tables: |
+        [
+            {
+              "name": "some_variables__name_value_pairs",
+              "columnNames": [
+                "name",
+                "value"
+              ],
+              "rows": [
+                {
+                  "row": [
+                    "John",
+                    "31"
+                  ]
+                },
+                {
+                  "row": [
+                    "Mark",
+                    "2"
+                  ]
+                },
+                {
+                  "row": [
+                    "Jane",
+                    "30"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "some_variables__table2",
+              "columnNames": [
+                "city",
+                "state"
+              ],
+              "rows": [
+                {
+                  "row": [
+                    "Baton Rouge",
+                    "LA"
+                  ]
+                },
+                {
+                  "row": [
+                    "Boulder",
+                    "CO"
+                  ]
+                }
+              ]
+            }
+          ]
+
+  iapp_template:
+    type: F5::Sys::iAppCompositeTemplate
+    depends_on: [bigip_rsrc, partition]
+    properties:
+      name: { get_param: iapp_template_name }
+      bigip_server: { get_resource: bigip_rsrc }
+      partition: { get_resource: partition }
+      requires_modules: [ ltm ]
+      presentation: |
+        include "/Common/f5.apl_common"
+
+        section hello_world {
+            message hello "Hello World!"
+        }
+        section some_variables {
+            string string_input_one
+            choice drop_down { 
+                "choice 1",
+                "choice 2"
+            }
+            multichoice multi {
+                "Option 1",
+                "Option 2",
+                "Bonus Option",
+                "Yet Another Option"
+            }
+            table name_value_pairs {
+                string name
+                string value
+            }
+            multichoice multi_2 {
+                "Test A",
+                "Test B",
+                "Test C"
+            }
+            table table2 {
+                string city
+                string state
+            }
+            noyes more_input
+            optional ( more_input == "Yes" ) {
+                string string_input_two
+            }
+        }
+
+        text {
+            hello_world "Greeting the World"
+            hello_world.hello "I say:"
+
+            some_variables "Some Input Fields"
+            some_variables.string_input_one    "Enter a string value."
+            some_variables.drop_down "Select a value."
+            some_variables.multi "Select one or more values."
+            some_variables.name_value_pairs    "Enter a list of name/value pairs"
+            some_variables.name_value_pairs.name "name"
+            some_variables.name_value_pairs.value "value"
+            some_variables.more_input "Do you want to enter another string?"
+            some_variables.string_input_two "Enter another string."
+        }
+      implementation: | 
+        tmsh::log_dest file
+        tmsh::log_level crit
+
+
+        puts " "
+        puts " "
+        puts "Starting the Lab 1 template."
+        puts " "
+
+        puts "The first string input |$::some_variables__string_input_one|"
+        puts "the drop-down choice |$::some_variables__drop_down|"
+        puts "The multichoice |$::some_variables__multi|"
+        puts "The name/value pairs |$::some_variables__name_value_pairs|"
+        if { $::some_variables__more_input == "Yes" } {
+            puts "The second string input |$::some_variables__string_input_two|"
+        }
+
+        puts " "
+        puts "Ending the Lab 1 template."
+        puts " "

--- a/unsupported/f5_plugins/deploy_lb.yaml
+++ b/unsupported/f5_plugins/deploy_lb.yaml
@@ -1,0 +1,298 @@
+description: >
+  This heat template demonstrates a basic load-balancing scenario on an F5 Device.
+
+heat_template_version: 2015-04-30
+
+parameters:
+  external_network:
+    default: external_network
+    description: External network used for floating IPs
+    label: External network name or ID
+    type: string
+    constraints:
+      - custom_constraint: neutron.network
+  client_image:
+    description: Image to serve as client
+    label: Client Glance Image
+    type: string
+    constraints:
+      - custom_constraint: glance.image
+  server_image:
+    description: Image to serve as server
+    label: Server Glance Image
+    type: string
+    constraints:
+      - custom_constraint: glance.image
+  client_server_flavor:
+    description: Flavor of client and server image
+    label: Client/Server Nova Flavor
+    type: string
+    constraints:
+      - custom_constraint: nova.flavor
+  key_name:
+    description: The public key to be pushed to instances
+    label: Key Name
+    type: string
+    constraints:
+      - custom_constraint: nova.keypair
+  client_server_sec_group:
+    description: Security group for client and server
+    label: Security Group
+    type: string
+    default: open
+  client_network:
+    description: Network for client traffic
+    label: Client Network
+    type: string
+    constraints:
+      - custom_constraint: neutron.network
+  server_network:
+    description: Network for server traffic
+    label: Server Network
+    type: string
+    constraints:
+      - custom_constraint: neutron.network
+  bigip_un:
+    description: BigIP Username
+    label: BigIP Login Username
+    type: string
+    default: admin
+  bigip_pw:
+    description: BigIP Password
+    label: BigIP Login Password
+    type: string
+    hidden: True
+  vs_name:
+    description: Virtual Server Name
+    label: Virtual Server Name
+    type: string
+    default: virtual_server1
+  pool_name:
+    description: Pool Name
+    label: Pool Name
+    type: string
+    default: pool1
+  bigip_fip:
+    description: BigIP Floating IP
+    label: BigIP FIP
+    type: string
+    constraints:
+      - custom_constraint: neutron.floating_ip
+  vs_vip:
+    description: Virtual Server Virtual IP
+    label: Virtual Server VIP
+    type: string
+  vs_port:
+    description: Virtual Server Port
+    label: Virtual Server Port
+    type: number
+    default: 443
+  pool_member_port:
+    description: Pool Member Port
+    label: Pool Member Port
+    type: number
+    default: 8080
+
+parameter_groups:
+  - label: Client and Server Parameters
+    parameters:
+      - client_image
+      - server_image
+      - client_server_flavor
+      - key_name
+  - label: Network Parameters
+    parameters:
+      - external_network
+      - client_server_sec_group
+      - client_network
+      - server_network
+  - label: BigIP Parameters 
+    parameters:
+      - bigip_fip
+      - bigip_un
+      - bigip_pw
+  - label: Load Balancing Parameters
+    parameters:
+      - vs_name
+      - vs_vip
+      - vs_port
+      - pool_name
+      - pool_member_port
+
+resources:
+  client_data_port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_param: client_network }
+      security_groups:
+        - { get_param: client_server_sec_group } 
+  client_fip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: external_network } 
+  client_fip_association:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: { get_resource: client_fip }
+      port_id: { get_resource: client_data_port }
+  client:
+    type: OS::Nova::Server
+    depends_on: server_wait_condition
+    properties:
+      name: client1
+      image: { get_param: client_image }
+      flavor: { get_param: client_server_flavor }
+      key_name: { get_param: key_name }
+      networks:
+        - port: { get_resource: client_data_port }
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          params:
+            __vs_vip__: { get_param: vs_vip }
+            __wc_notify__: { get_attr: ['client_wait_handle', 'curl_cli'] }
+          template: |
+            #!/bin/bash -ex
+            curl -k https://__vs_vip__
+            __wc_notify__ --data-binary '{"status": "SUCCESS"}'
+  client_wait_condition:
+    type: OS::Heat::WaitCondition
+    properties:
+      handle: { get_resource: client_wait_handle }
+      timeout: 1200
+      count: 1
+  client_wait_handle:
+    type: OS::Heat::WaitConditionHandle
+  server_wait_condition:
+    type: OS::Heat::WaitCondition
+    properties:
+      handle: { get_resource: server_wait_handle }
+      timeout: 1200
+      count: 1
+  server_wait_handle:
+    type: OS::Heat::WaitConditionHandle
+  server_data_port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_param: server_network }
+      security_groups:
+        - { get_param: client_server_sec_group } 
+  server_fip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: external_network } 
+  server_fip_association:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: { get_resource: server_fip }
+      port_id: { get_resource: server_data_port }
+  server:
+    type: OS::Nova::Server
+    properties:
+      name: server
+      image: { get_param: server_image }
+      flavor: { get_param: client_server_flavor }
+      key_name: { get_param: key_name }
+      networks:
+        - port: { get_resource: server_data_port }
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          params:
+            __wc_notify__: { get_attr: ['server_wait_handle', 'curl_cli'] }
+            __rs_port__: { get_param: pool_member_port }
+          template: |
+            #!/bin/bash -ex
+            nohup http-server -p __rs_port__ &
+            __wc_notify__ --data-binary '{"status": "SUCCESS"}'
+  bigip:
+    type: F5::BigIP::Device
+    properties:
+      ip: { get_param: bigip_fip }
+      username: { get_param: bigip_un }
+      password: { get_param: bigip_pw }
+  partition:
+    type: F5::Sys::Partition
+    depends_on: bigip
+    properties:
+      name: Common
+      bigip_server: { get_resource: bigip }
+  iapp_service:
+    type: F5::Sys::iAppService
+    depends_on: iapp_template
+    properties:
+      name: lb_service
+      bigip_server: { get_resource: bigip }
+      partition: { get_resource: partition }
+      template_name: alb_templ
+      traffic_group: /Common/traffic-group-local-only
+  iapp_template:
+    type: F5::Sys::iAppCompositeTemplate
+    depends_on: partition
+    properties:
+      name: alb_templ
+      bigip_server: { get_resource: bigip }
+      partition: { get_resource: partition }
+      requires_modules: [ ltm ]
+      implementation:
+        str_replace:
+          params:
+            __partition__: Common
+            __pool_name__: { get_param: pool_name }
+            __vs_name__: { get_param: vs_name }
+            __vip__: { get_param: vs_vip }
+            __vs_port__: { get_param: vs_port }
+            __rs_port__: { get_param: pool_member_port }
+            __rs_ip__: { get_attr: [server, first_address] }
+          template: |
+            tmsh::create {
+                ltm pool /__partition__/__pool_name__
+                    load-balancing-mode least-connections-node
+                    members replace-all-with {
+                        __rs_ip__:__rs_port__ {
+                            address __rs_ip__
+                        }
+                    }
+            }
+
+            tmsh::create {
+                ltm virtual /__partition__/__vs_name__
+                    connection-limit 1
+                    destination /__partition__/__vip__:__vs_port__
+                    mask 255.255.255.255
+                    pool /__partition__/__pool_name__
+                    profiles replace-all-with {
+                        /Common/clientssl {
+                            context clientside
+                        }
+                    }
+                    source 0.0.0.0/0
+                    source-address-translation {
+                        type automap
+                    }
+                    translate-address enabled
+                    translate-port enabled
+                    vlans replace-all-with {
+                        /Common/network-1.1
+                    }
+                    vlans-enabled
+            }
+
+            tmsh::create {
+                ltm virtual-address /__partition__/__vip__
+                    address __vip__
+                    arp enabled
+                    icmp-echo enabled
+                    mask 255.255.255.255
+                    traffic-group traffic-group-1
+            }
+      presentation: |
+        section say_hello {
+            message intro "This template deploys a virtual server and a pool with two members."
+        }
+
+outputs:
+  client_curl_cli:
+    value: { get_attr: [client_wait_handle, curl_cli] }
+  server_curl_cli:
+    value: { get_attr: [server_wait_handle, curl_cli] }

--- a/unsupported/f5_plugins/examples.rst
+++ b/unsupported/f5_plugins/examples.rst
@@ -1,0 +1,10 @@
+F5 Heat Plugin Example Templates
+================================
+
+Prerequisites
+-------------
+To launch the templates within, you must install the F5 Heat plugins from `F5's Github Repository <https://github.com/F5Networks/f5-openstack-heat-plugins>`. The readme file there will instruct you how to deploy them in your own OpenStack.
+
+Description
+-----------
+The templates in this directory demonstrate how to use F5 Heat resources. A good starting point is the deploy_composite_iapp.yaml Heat template. It shows how to deploy an F5::Sys::iAppCompositeTemplate and F5::Sys::iAppService resource in Heat, which creates an iApp service on the BigIP. An iApp is a specific configuration deployment represented as an executable TCL script. The script is call an iApp Template. There are two ways to deploy iApp Templates with F5's Heat plugins: the first is as shown in deploy_composite_iapp.yaml--F5::Sys::iAppCompositeTemplate, and the other method is a simple dump of the full TCL file into the Heat template--F5::Sys::iAppFullTemplate. Once the template has been created on the BigIP device, it can then be executed to create the iApp Service--F5::Sys::iAppService. Examples of each plugin we support exist in this directory. Feel free to browse around and tweak those parameters and resources to suit your needs.

--- a/unsupported/f5_plugins/heat_composition/heat_composition.rst
+++ b/unsupported/f5_plugins/heat_composition/heat_composition.rst
@@ -1,0 +1,6 @@
+Heat Composition
+================
+
+Description
+-----------
+The templates within offer examples of how to perform Heat template composition. This is not the only way to do Heat template composition. Refer to the `Openstack Template Composition <http://docs.openstack.org/developer/heat/template_guide/composition.html>` for more information on this way to compose Heat templates. These are specifically using composition and the F5 Heat plugins to stand up a load-balancing scenario. The client issues a curl request to the virtual IP address, and that request is proxied to the backend pool member. Both the client and the server are created in the template, but the underlying private networks they connect to are not. The other important note is that the VE itself is not created in these templates, we are merely interacting with an existing VE.

--- a/unsupported/f5_plugins/heat_composition/iapp_client.yaml
+++ b/unsupported/f5_plugins/heat_composition/iapp_client.yaml
@@ -1,0 +1,92 @@
+heat_template_version: 2015-04-30
+
+description: Creates a client instance which curls a Virtual IP
+
+parameters:
+  external_network:
+    default: external_network
+    description: External network used for floating IPs
+    label: External network name or ID
+    type: string
+    constraints:
+      - custom_constraint: neutron.network
+  client_image:
+    description: Image to serve as client
+    label: Client Glance Image
+    type: string
+    constraints:
+      - custom_constraint: glance.image
+  client_server_flavor:
+    description: Flavor of client and server image
+    label: Client/Server Nova Flavor
+    type: string
+    constraints:
+      - custom_constraint: nova.flavor
+  key_name:
+    description: The public key to be pushed to instances
+    label: Key Name
+    type: string
+    constraints:
+      - custom_constraint: nova.keypair
+  client_server_sec_group:
+    description: Security group for client and server
+    label: Security Group
+    type: string
+    default: open
+  client_network:
+    description: Network for client traffic
+    label: Client Network
+    type: string
+    constraints:
+      - custom_constraint: neutron.network
+  vs_vip:
+    description: Virtual IP Address for Virtual Server
+    label: VS VIP
+    type: string
+resources:
+  client_data_port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_param: client_network }
+      security_groups:
+        - { get_param: client_server_sec_group }
+  client_fip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: external_network }
+  client_fip_association:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: { get_resource: client_fip }
+      port_id: { get_resource: client_data_port }
+  client:
+    type: OS::Nova::Server
+    properties:
+      name: client1
+      image: { get_param: client_image }
+      flavor: { get_param: client_server_flavor }
+      key_name: { get_param: key_name }
+      networks:
+        - port: { get_resource: client_data_port }
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          params:
+            __vs_vip__: { get_param: vs_vip }
+            __wc_notify__: { get_attr: ['client_wait_handle', 'curl_cli'] }
+          template: |
+            #!/bin/bash -ex
+            curl -k https://__vs_vip__
+            __wc_notify__ --data-binary '{"status": "SUCCESS"}'
+  client_wait_condition:
+    type: OS::Heat::WaitCondition
+    properties:
+      handle: { get_resource: client_wait_handle }
+      timeout: 1200
+      count: 1
+  client_wait_handle:
+    type: OS::Heat::WaitConditionHandle
+
+outputs:
+  client_curl_cli:
+    value: { get_attr: [client_wait_handle, curl_cli] }

--- a/unsupported/f5_plugins/heat_composition/iapp_env.yaml
+++ b/unsupported/f5_plugins/heat_composition/iapp_env.yaml
@@ -1,0 +1,2 @@
+resource_registry:
+  Iapp::Client::CurlHTTPS: iapp_client.yaml

--- a/unsupported/f5_plugins/heat_composition/iapp_lb_deploy.yaml
+++ b/unsupported/f5_plugins/heat_composition/iapp_lb_deploy.yaml
@@ -1,0 +1,264 @@
+description: >
+  This heat template demonstrates a basic load-balancing scenario on an F5 Device.
+
+heat_template_version: 2015-04-30
+
+parameters:
+  external_network:
+    default: external_network
+    description: External network used for floating IPs
+    label: External network name or ID
+    type: string
+    constraints:
+      - custom_constraint: neutron.network
+  client_image:
+    description: Image to serve as client
+    label: Client Glance Image
+    type: string
+    constraints:
+      - custom_constraint: glance.image
+  server_image:
+    description: Image to serve as server
+    label: Server Glance Image
+    type: string
+    constraints:
+      - custom_constraint: glance.image
+  client_server_flavor:
+    description: Flavor of client and server image
+    label: Client/Server Nova Flavor
+    type: string
+    constraints:
+      - custom_constraint: nova.flavor
+  key_name:
+    description: The public key to be pushed to instances
+    label: Key Name
+    type: string
+    constraints:
+      - custom_constraint: nova.keypair
+  client_server_sec_group:
+    description: Security group for client and server
+    label: Security Group
+    type: string
+    default: open
+  client_network:
+    description: Network for client traffic
+    label: Client Network
+    type: string
+    constraints:
+      - custom_constraint: neutron.network
+  server_network:
+    description: Network for server traffic
+    label: Server Network
+    type: string
+    constraints:
+      - custom_constraint: neutron.network
+  bigip_un:
+    description: BigIP Username
+    label: BigIP Login Username
+    type: string
+    default: admin
+  bigip_pw:
+    description: BigIP Password
+    label: BigIP Login Password
+    type: string
+    hidden: True
+  vs_name:
+    description: Virtual Server Name
+    label: Virtual Server Name
+    type: string
+    default: virtual_server1
+  pool_name:
+    description: Pool Name
+    label: Pool Name
+    type: string
+    default: pool1
+  bigip_fip:
+    description: BigIP Floating IP
+    label: BigIP FIP
+    type: string
+    constraints:
+      - custom_constraint: neutron.floating_ip
+  vs_vip:
+    description: Virtual Server Virtual IP
+    label: Virtual Server VIP
+    type: string
+  vs_port:
+    description: Virtual Server Port
+    label: Virtual Server Port
+    type: number
+    default: 443
+  pool_member_port:
+    description: Pool Member Port
+    label: Pool Member Port
+    type: number
+    default: 8080
+
+parameter_groups:
+  - label: Client and Server Parameters
+    parameters:
+      - client_image
+      - server_image
+      - client_server_flavor
+      - key_name
+  - label: Network Parameters
+    parameters:
+      - external_network
+      - client_server_sec_group
+      - client_network
+      - server_network
+  - label: BigIP Parameters 
+    parameters:
+      - bigip_fip
+      - bigip_un
+      - bigip_pw
+  - label: Load Balancing Parameters
+    parameters:
+      - vs_name
+      - vs_vip
+      - vs_port
+      - pool_name
+      - pool_member_port
+
+resources:
+  client:
+    type: Iapp::Client::CurlHTTPS
+    depends_on: server_wait_condition
+    properties:
+      client_image: { get_param: client_image }
+      client_server_flavor: { get_param: client_server_flavor }
+      key_name: { get_param: key_name }
+      external_network: { get_param: external_network }
+      client_server_sec_group: { get_param: client_server_sec_group }
+      client_network: { get_param: client_network }
+      vs_vip: { get_param: vs_vip }
+  server_wait_condition:
+    type: OS::Heat::WaitCondition
+    properties:
+      handle: { get_resource: server_wait_handle }
+      timeout: 1200
+      count: 1
+  server_wait_handle:
+    type: OS::Heat::WaitConditionHandle
+  server_data_port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_param: server_network }
+      security_groups:
+        - { get_param: client_server_sec_group } 
+  server_fip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: external_network } 
+  server_fip_association:
+    type: OS::Neutron::FloatingIPAssociation
+    properties:
+      floatingip_id: { get_resource: server_fip }
+      port_id: { get_resource: server_data_port }
+  server:
+    type: OS::Nova::Server
+    properties:
+      name: server
+      image: { get_param: server_image }
+      flavor: { get_param: client_server_flavor }
+      key_name: { get_param: key_name }
+      networks:
+        - port: { get_resource: server_data_port }
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          params:
+            __wc_notify__: { get_attr: ['server_wait_handle', 'curl_cli'] }
+            __rs_port__: { get_param: pool_member_port }
+          template: |
+            #!/bin/bash -ex
+            nohup http-server -p __rs_port__ &
+            __wc_notify__ --data-binary '{"status": "SUCCESS"}'
+  bigip:
+    type: F5::BigIP::Device
+    properties:
+      ip: { get_param: bigip_fip }
+      username: { get_param: bigip_un }
+      password: { get_param: bigip_pw }
+  partition:
+    type: F5::Sys::Partition
+    depends_on: bigip
+    properties:
+      name: Common
+      bigip_server: { get_resource: bigip }
+  iapp_service:
+    type: F5::Sys::iAppService
+    depends_on: [partition, iapp_template]
+    properties:
+      name: lb_service
+      bigip_server: { get_resource: bigip }
+      partition: { get_resource: partition }
+      template_name: alb_templ
+      traffic_group: /Common/traffic-group-local-only
+  iapp_template:
+    type: F5::Sys::iAppCompositeTemplate
+    depends_on: partition
+    properties:
+      name: alb_templ
+      bigip_server: { get_resource: bigip }
+      partition: { get_resource: partition }
+      requires_modules: [ ltm ]
+      implementation:
+        str_replace:
+          params:
+            __partition__: Common
+            __pool_name__: { get_param: pool_name }
+            __vs_name__: { get_param: vs_name }
+            __vip__: { get_param: vs_vip }
+            __vs_port__: { get_param: vs_port }
+            __rs_port__: { get_param: pool_member_port }
+            __rs_ip__: { get_attr: [server, first_address] }
+          template: |
+            tmsh::create {
+                ltm pool /__partition__/__pool_name__
+                    load-balancing-mode least-connections-node
+                    members replace-all-with {
+                        __rs_ip__:__rs_port__ {
+                            address __rs_ip__
+                        }
+                    }
+            }
+
+            tmsh::create {
+                ltm virtual /__partition__/__vs_name__
+                    connection-limit 1
+                    destination /__partition__/__vip__:__vs_port__
+                    mask 255.255.255.255
+                    pool /__partition__/__pool_name__
+                    profiles replace-all-with {
+                        /Common/clientssl {
+                            context clientside
+                        }
+                    }
+                    source 0.0.0.0/0
+                    source-address-translation {
+                        type automap
+                    }
+                    translate-address enabled
+                    translate-port enabled
+                    vlans replace-all-with {
+                        /Common/network-1.1
+                    }
+                    vlans-enabled
+            }
+
+            tmsh::create {
+                ltm virtual-address /__partition__/__vip__
+                    address __vip__
+                    arp enabled
+                    icmp-echo enabled
+                    mask 255.255.255.255
+                    traffic-group traffic-group-1
+            }
+      presentation: |
+        section say_hello {
+            message intro "This template deploys a virtual server and a pool with two members."
+        }
+
+outputs:
+  server_curl_cli:
+    value: { get_attr: [server_wait_handle, curl_cli] }

--- a/unsupported/f5_plugins/iapp_answers/lab_1_list.json
+++ b/unsupported/f5_plugins/iapp_answers/lab_1_list.json
@@ -1,0 +1,19 @@
+[
+    {
+      "name": "some_variables__multi",
+      "encrypted": "no",
+      "value": [
+        "Option 1",
+        "Bonus Option",
+        "Yet Another Option"
+      ]
+    },
+    {
+      "name": "some_variables__multi_2",
+      "encrypted": "no",
+      "value": [
+        "Test A",
+        "Test B"
+      ]
+    }
+]

--- a/unsupported/f5_plugins/pool.yaml
+++ b/unsupported/f5_plugins/pool.yaml
@@ -1,0 +1,69 @@
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+heat_template_version: 2015-04-30
+
+description: Test of creating a pool on an existing VE server
+
+parameters:
+  pool_name:
+    type: string
+    label: Pool Name
+    default: test_pool
+  ve_instance:
+    type: string
+    label: VE Instance IP
+    description: IP of existing VE
+  bigip_un:
+    type: string
+    label: BigIP Login Username
+    default: admin
+  bigip_pw:
+    type: string
+    label: BigIP Login Password
+    hidden: true
+parameter_groups:
+  - label: VE Parameters
+    parameters:
+      - ve_instance
+      - bigip_un
+      - bigip_pw
+  - label: Pool Parameters
+    parameters:
+      - pool_name
+resources:
+  bigip_rsrc:
+    type: F5::BigIP::Device
+    properties:
+      ip: { get_param: ve_instance }
+      username: { get_param: bigip_un }
+      password: { get_param: bigip_pw }
+  partition:
+    type: F5::Sys::Partition
+    depends_on: bigip_rsrc
+    properties:
+      name: Common
+      bigip_server: { get_resource: bigip_rsrc }
+  ve_pool:
+    type: F5::LTM::Pool
+    properties:
+      name: { get_param: pool_name }
+      bigip_server: { get_resource: bigip_rsrc }
+      partition: { get_resource: partition }
+      members:
+        - member_ip: 129.0.0.2
+          member_port: 80
+        - member_ip: 130.0.0.2
+          member_port: 80

--- a/unsupported/f5_plugins/virtual_server.yaml
+++ b/unsupported/f5_plugins/virtual_server.yaml
@@ -1,0 +1,77 @@
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+heat_template_version: 2015-04-30
+
+description: Test of creating a pool on an existing VE server
+
+parameters:
+  vs_name:
+    type: string
+    label: Pool Name
+    default: test_pool
+  vs_ip:
+    type: string
+    label: Virtual Server IP
+    default: 128.0.0.1
+  vs_port:
+    type: number
+    label: Virtual Server Port
+    default: 80
+  ve_instance:
+    type: string
+    label: VE Instance IP
+    description: IP of existing VE
+  bigip_un:
+    type: string
+    label: BigIP Login Username
+    default: admin
+  bigip_pw:
+    type: string
+    label: BigIP Login Password
+    hidden: true
+parameter_groups:
+  - label: VE Parameters
+    parameters:
+      - ve_instance
+      - bigip_un
+      - bigip_pw
+  - label: Pool Parameters
+    parameters:
+      - vs_name
+      - vs_ip
+      - vs_port
+resources:
+  bigip_rsrc:
+    type: F5::BigIP::Device
+    properties:
+      ip: { get_param: ve_instance }
+      username: { get_param: bigip_un }
+      password: { get_param: bigip_pw }
+  partition:
+    type: F5::Sys::Partition
+    depends_on: bigip_rsrc
+    properties:
+      name: Common
+      bigip_server: { get_resource: bigip_rsrc }
+  virtual_server:
+    type: F5::LTM::VirtualServer
+    depends_on: [bigip_rsrc, partition]
+    properties:
+      bigip_server: { get_resource: bigip_rsrc }
+      partition: { get_resource: partition }
+      name: { get_param: vs_name }
+      ip: { get_param: vs_ip }
+      port: { get_param: vs_port }


### PR DESCRIPTION
Issues: Fixes: Issue #28

Problem: Moving heat plugins templates to this repo

Analysis: The template from f5-openstack-heat plugins have been
consolidated and moved to a new direcotry called f5_plugins in the
unsupported directory

Tests: