### PR TITLE
Update patch image template

### DIFF
--- a/unsupported/ve/images/patch_upload_ve_image.yaml
+++ b/unsupported/ve/images/patch_upload_ve_image.yaml
@@ -157,11 +157,11 @@ resources:
             # download f5 packages
             cd /home/imageprep
             
+            apt-get update
             apt-get install -y git
             git clone __image_prep_url__
 
             # install packages
-            apt-get update
             apt-get -y install unzip qemu-utils lvm2 python-keystoneclient python-glanceclient python-eventlet python-suds python-paramiko
             
             # sync images


### PR DESCRIPTION
Issues: Fixes Issue #37

Problem: This template needs to perform a apt-get update on the ubuntu
server before installing other software, or else the user-data script
could fail.

Analysis: Inserted an apt-get update command before installing git

Tests: Manually tested this deployment several times