### PR TITLE
Update standalone template documentation

### DIFF
--- a/unsupported/ve/standalone/standalone.rst
+++ b/unsupported/ve/standalone/standalone.rst
@@ -10,6 +10,13 @@ The standalone templates utilize the same configuration settings as those in the
 
 .. note::
 
+    * These templates must be launched via the python-heatclient. This is due to an issue with launching composite templates via Horizon in OpenStack Kilo.
+    * To launch, source your keystone credentials and run:
+        heat stack-create -f <template_file> -P <param1_key=value;param2_key=value> test_stack
+    * Some parameters in these templates have default values, yet others require user input. In addition to this, you may have to create certain resources before launching the template (such as the data and management networks).
+
+.. note::
+
     * The license key is a required input parameter if you wish to boot up a licensed VE. The license must include the VE modules you wish to provision.
 
     * The outputs of these templates give you a programmatic way to retrieve details about the VE.


### PR DESCRIPTION
@jputrino 

Issues: Fixes #41

Problem: Documentation for standalone templates need better explanation
on how to launch a stack

Analysis: Modified it to show users an example of launching via the heat
client

Tests: