### PR TITLE
Travis configs update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
     - pip install -r requirements.test.txt
 script:
     - flake8 --exclude=docs .
-    - cd docs; make html
+    - sphinx-build -W docs/ docs/_build/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,7 +164,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,16 @@
 import os
 import sys
 
+# Ignore external image warnings in Sphinx builds
+
+import sphinx.environment
+from docutils.utils import get_source_line
+
+def _warn_node(self, msg, node):
+    if not msg.startswith('nonlocal image URI found:'):
+        self._warnfunc(msg, '%s:%s' % get_source_line(node))
+
+sphinx.environment.BuildEnvironment.warn_node = _warn_node
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/f5-supported/f5-supported-index.rst
+++ b/docs/f5-supported/f5-supported-index.rst
@@ -5,7 +5,7 @@
     :maxdepth: 2
 
 F5®-Supported Heat Templates
-===========================
+============================
 
 .. include:: ../../f5_supported/README.rst
     :start-line: 3

--- a/docs/unsupported/f5-bigip-ve_doc.rst
+++ b/docs/unsupported/f5-bigip-ve_doc.rst
@@ -13,7 +13,6 @@ We have four sets of Heat templates that can be used with BIG-IP® VE:
 
 .. toctree::
     :titlesonly:
-    :maxdepth: 1
 
     Image Templates <ve-images>
     Plugin Templates <f5-iapps-plugins_doc>

--- a/docs/unsupported/f5-iapps-plugins_doc.rst
+++ b/docs/unsupported/f5-iapps-plugins_doc.rst
@@ -10,5 +10,5 @@ F5® iApps® Plugins
     :titlesonly:
     :glob:
 
-    f5_plugins/*
+    *iapp
 

--- a/docs/unsupported/unsupported-index.rst
+++ b/docs/unsupported/unsupported-index.rst
@@ -15,11 +15,7 @@ Unsupported Heat Templates
 .. toctree::
 
     Learning Stacks <learning-stacks_doc>
-    F5® iApps® Plugins <f5-iapps-plugins_doc>
     F5® BIG-IP® VE <f5-bigip-ve_doc>
+    F5® iApps® Plugins <f5-iapps-plugins_doc>
     Service Providers <service-providers_doc>
-
-
-
-
 

--- a/docs/unsupported/ve-images.rst
+++ b/docs/unsupported/ve-images.rst
@@ -7,5 +7,3 @@
 .. toctree::
     :maxdepth: 1
     :glob:
-
-    ../../unsupported/ve/images/*


### PR DESCRIPTION
@pjbreaux 

Fixes #47 - configure travis to treat sphinx warnings as errors

#### What's this change do?
- changed the script that builds the docs in travis
- added code to conf.py that will ignore sphinx's 'external image' warnings
- fixed errors triggered by the sphinx build command 

#### Where should the reviewer start?
View changes below.

#### Any background context?