### PR TITLE
Patched VE images torn down even though no-teardown flag is given to pytest

### DIFF
--- a/requirements.func.test.txt
+++ b/requirements.func.test.txt
@@ -1,5 +1,4 @@
-python-heatclient
-python-glanceclient
-f5-openstack-heat-plugins
+git+https://github.com/F5Networks/f5-openstack-test.git@liberty
 hacking
+f5-openstack-heat-plugins
 Sphinx==1.3.5

--- a/requirements.func.test.txt
+++ b/requirements.func.test.txt
@@ -1,3 +1,4 @@
+Babel==2.2.0
 git+https://github.com/F5Networks/f5-openstack-test.git@liberty
 hacking
 f5-openstack-heat-plugins

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -14,6 +14,7 @@
 #
 #
 
+import os
 import pytest
 
 
@@ -24,7 +25,8 @@ def pytest_addoption(parser):
                      help='Default BIGIP root password')
     parser.addoption('--license', action='store',
                      help='BIGIP license key')
-    parser.addoption('--no-teardown-glance-images', action='store_false',
+    parser.addoption('--no-teardown-glance-images', action='store_true',
+                     default=False,
                      help='Include if you do not wish to remove images '
                      'pushed into glance.')
 
@@ -46,3 +48,17 @@ def OSPassword(request):
 @pytest.fixture
 def AuthAddress(request):
     return request.config.getoption('--auth-netloc')
+
+
+@pytest.fixture
+def UnsupportedDir():
+    base_repo_dir = \
+        os.path.dirname(
+            os.path.dirname(
+                os.path.dirname(
+                    os.path.abspath(__file__)
+                )
+            )
+        )
+    unsupported_dir = os.path.join(base_repo_dir, 'unsupported')
+    return unsupported_dir

--- a/test/functional/ve/images/test_patch_upload_ve_image.py
+++ b/test/functional/ve/images/test_patch_upload_ve_image.py
@@ -17,7 +17,7 @@
 import os
 import pytest
 
-HEAT_DIR = '/root/heat/unsupported/ve/images'
+
 BIGIP_12_0_IMG = 'BIGIP-12.0.0.0.0.606'
 BIGIP_11_6_IMG = 'BIGIP-11.6.0.0.0.401'
 BIGIP_11_5_4_IMG = 'BIGIP-11.5.4.0.0.256'
@@ -38,15 +38,25 @@ def GlanceImageCleanup(request, glanceclientmanager):
     return manage_glance
 
 
+@pytest.fixture
+def PatchTemplateLoc(UnsupportedDir):
+    return os.path.join(
+        os.path.join(
+            UnsupportedDir, 've', 'images', 'patch_upload_ve_image.yaml'
+        )
+    )
+
+
 def test_patched_image_upload_12_0(
         HeatStack,
         GlanceImageCleanup,
         OSPassword,
         AuthAddress,
-        glanceclientmanager
+        glanceclientmanager,
+        PatchTemplateLoc
 ):
     hc, stack = HeatStack(
-        os.path.join(HEAT_DIR, 'patch_upload_ve_image.yaml'),
+        PatchTemplateLoc,
         'func_test_patch_ve_image',
         parameters={
             'onboard_image': 'ubuntu_14.04_lts',
@@ -56,7 +66,7 @@ def test_patched_image_upload_12_0(
             'f5_ve_image_url':
             'http://10.190.0.20/~breaux/BIGIP-12.0.0.0.0.606.LTM.qcow2.zip',
             'f5_ve_image_name': BIGIP_12_0_IMG + '.qcow2',
-            # 'apt_cache_proxy_url': 'http://apt-cache.pdbld.f5net.com:3142',
+            'apt_cache_proxy_url': 'http://apt-cache.pdbld.f5net.com:3142',
             'f5_image_import_auth_url':
             'http://{}:5000/v2.0'.format(AuthAddress)
         }
@@ -71,10 +81,11 @@ def test_patched_image_upload_11_6(
         GlanceImageCleanup,
         OSPassword,
         AuthAddress,
-        glanceclientmanager
+        glanceclientmanager,
+        PatchTemplateLoc
 ):
     hc, stack = HeatStack(
-        os.path.join(HEAT_DIR, 'patch_upload_ve_image.yaml'),
+        PatchTemplateLoc,
         'func_test_patch_ve_image',
         parameters={
             'onboard_image': 'ubuntu_14.04_lts',
@@ -83,6 +94,7 @@ def test_patched_image_upload_11_6(
             'f5_image_import_password': OSPassword,
             'f5_ve_image_url':
             'http://10.190.0.20/~breaux/BIGIP-11.6.0.0.0.401.LTM.qcow2.zip',
+            'apt_cache_proxy_url': 'http://apt-cache.pdbld.f5net.com:3142',
             'f5_ve_image_name': BIGIP_11_6_IMG + '.qcow2',
             'f5_image_import_auth_url':
             'http://{}:5000/v2.0'.format(AuthAddress)
@@ -98,10 +110,11 @@ def test_patched_image_upload_11_5(
         GlanceImageCleanup,
         OSPassword,
         AuthAddress,
-        glanceclientmanager
+        glanceclientmanager,
+        PatchTemplateLoc
 ):
     hc, stack = HeatStack(
-        os.path.join(HEAT_DIR, 'patch_upload_ve_image.yaml'),
+        PatchTemplateLoc,
         'func_test_patch_ve_image',
         parameters={
             'onboard_image': 'ubuntu_14.04_lts',

--- a/test/functional/ve/standalone/test_f5_base_instance_deploy.py
+++ b/test/functional/ve/standalone/test_f5_base_instance_deploy.py
@@ -16,10 +16,10 @@
 
 from f5.bigip import BigIP
 import os
+import pytest
 import time
 
 
-HEAT_DIR = '/root/heat/unsupported/ve/common'
 BIGIP_11_5_4_IMG = 'BIGIP-11.5.4.0.0.256'
 BIGIP_11_5_4_VERSION = '11.5.4'
 BIGIP_11_6_IMG = 'BIGIP-11.6.0.0.0.401'
@@ -53,12 +53,23 @@ def wait_for_active_licensed_bigip(
             continue
 
 
+@pytest.fixture
+def CommonTemplateDir(UnsupportedDir):
+    return os.path.join(
+        os.path.join(
+            UnsupportedDir, 've', 'common'
+        )
+    )
+
+
 # These tests require a patched VE instance in your stack
 
-def itest_f5_base_instance_deploy_3_nic_11_5_4(HeatStack, BigIPConfig):
+def itest_f5_base_instance_deploy_3_nic_11_5_4(
+        HeatStack, BigIPConfig, CommonTemplateDir
+):
     admin_password, root_password, license = BigIPConfig
     hc, stack = HeatStack(
-        os.path.join(HEAT_DIR, 'f5_ve_standalone_3_nic.yaml'),
+        os.path.join(CommonTemplateDir, 'f5_ve_standalone_3_nic.yaml'),
         'func_test_standalone_3_nic',
         parameters={
             've_image': BIGIP_11_5_4_IMG,
@@ -79,10 +90,12 @@ def itest_f5_base_instance_deploy_3_nic_11_5_4(HeatStack, BigIPConfig):
     )
 
 
-def test_f5_base_instance_deploy_3_nic_11_6(HeatStack, BigIPConfig):
+def test_f5_base_instance_deploy_3_nic_11_6(
+        HeatStack, BigIPConfig, CommonTemplateDir
+):
     admin_password, root_password, license = BigIPConfig
     hc, stack = HeatStack(
-        os.path.join(HEAT_DIR, 'f5_ve_standalone_3_nic.yaml'),
+        os.path.join(CommonTemplateDir, 'f5_ve_standalone_3_nic.yaml'),
         'func_test_standalone_3_nic',
         parameters={
             've_image': BIGIP_11_6_IMG,
@@ -103,10 +116,12 @@ def test_f5_base_instance_deploy_3_nic_11_6(HeatStack, BigIPConfig):
     )
 
 
-def test_f5_base_instance_deploy_3_nic_12_0(HeatStack, BigIPConfig):
+def test_f5_base_instance_deploy_3_nic_12_0(
+        HeatStack, BigIPConfig, CommonTemplateDir
+):
     admin_password, root_password, license = BigIPConfig
     hc, stack = HeatStack(
-        os.path.join(HEAT_DIR, 'f5_ve_standalone_3_nic.yaml'),
+        os.path.join(CommonTemplateDir, 'f5_ve_standalone_3_nic.yaml'),
         'func_test_standalone_3_nic',
         parameters={
             've_image': BIGIP_12_0_IMG,

--- a/test/functional/ve/standalone/test_f5_base_instance_deploy.py
+++ b/test/functional/ve/standalone/test_f5_base_instance_deploy.py
@@ -48,6 +48,9 @@ def wait_for_active_licensed_bigip(
         try:
             registration = bigip.shared.licensing.registration.load()
             assert registration.licensedVersion == bigip_version
+            assert len(bigip.net.vlans.get_collection()) == 2
+            assert len(bigip.net.interfaces.get_collection()) == 3
+            assert len(bigip.net.selfips.get_collection()) == 2
             return bigip
         except Exception:
             continue

--- a/test/functional/ve/standalone/test_f5_base_instance_deploy.py
+++ b/test/functional/ve/standalone/test_f5_base_instance_deploy.py
@@ -48,9 +48,24 @@ def wait_for_active_licensed_bigip(
         try:
             registration = bigip.shared.licensing.registration.load()
             assert registration.licensedVersion == bigip_version
-            return
+            return bigip
         except Exception:
             continue
+
+
+def check_net_components(bigip):
+    expected_ifc_names = ['1.1', '1.2', 'mgmt']
+    expected_selfip_names = ['selfip.network-1.1', 'selfip.network-1.2']
+    expected_vlan_names = ['network-1.1', 'network-1.2']
+    ifcs = bigip.net.interfaces.get_collection()
+    ifc_names = [ifc.name for ifc in ifcs]
+    assert expected_ifc_names == ifc_names
+    selfips = bigip.net.selfips.get_collection()
+    selfip_names = [selfip.name for selfip in selfips]
+    assert expected_selfip_names == selfip_names
+    vlans = bigip.net.vlans.get_collection()
+    vlan_names = [vlan.name for vlan in vlans]
+    assert expected_vlan_names == vlan_names
 
 
 @pytest.fixture
@@ -85,9 +100,10 @@ def itest_f5_base_instance_deploy_3_nic_11_5_4(
     )
     updated_stack = hc.stacks.get(stack.id)
     floating_ip = get_floating_ip_output(updated_stack)
-    wait_for_active_licensed_bigip(
+    bigip = wait_for_active_licensed_bigip(
         floating_ip, 'admin', admin_password, BIGIP_11_5_4_VERSION
     )
+    check_net_components(bigip)
 
 
 def test_f5_base_instance_deploy_3_nic_11_6(
@@ -111,9 +127,10 @@ def test_f5_base_instance_deploy_3_nic_11_6(
     )
     updated_stack = hc.stacks.get(stack.id)
     floating_ip = get_floating_ip_output(updated_stack)
-    wait_for_active_licensed_bigip(
+    bigip = wait_for_active_licensed_bigip(
         floating_ip, 'admin', admin_password, BIGIP_11_6_VERSION
     )
+    check_net_components(bigip)
 
 
 def test_f5_base_instance_deploy_3_nic_12_0(
@@ -137,6 +154,7 @@ def test_f5_base_instance_deploy_3_nic_12_0(
     )
     updated_stack = hc.stacks.get(stack.id)
     floating_ip = get_floating_ip_output(updated_stack)
-    wait_for_active_licensed_bigip(
+    bigip = wait_for_active_licensed_bigip(
         floating_ip, 'admin', admin_password, BIGIP_12_0_VERSION
     )
+    check_net_components(bigip)

--- a/test/functional/ve/standalone/test_f5_base_instance_deploy.py
+++ b/test/functional/ve/standalone/test_f5_base_instance_deploy.py
@@ -58,8 +58,8 @@ def wait_for_active_licensed_bigip(
 
 def check_net_components(bigip):
     expected_ifc_names = ['1.1', '1.2', 'mgmt']
-    expected_selfip_names = ['selfip.network-1.1', 'selfip.network-1.2']
-    expected_vlan_names = ['network-1.1', 'network-1.2']
+    expected_selfip_names = [u'selfip.network-1.1', u'selfip.network-1.2']
+    expected_vlan_names = [u'network-1.1', u'network-1.2']
     ifcs = bigip.net.interfaces.get_collection()
     ifc_names = [ifc.name for ifc in ifcs]
     assert expected_ifc_names == ifc_names

--- a/test/functional/ve/standalone/test_f5_base_instance_deploy.py
+++ b/test/functional/ve/standalone/test_f5_base_instance_deploy.py
@@ -59,17 +59,17 @@ def wait_for_active_licensed_bigip(
             return bigip
         except Exception:
             continue
+    pytest.fail('Too many attempts made to contact the BigIP. Failing...')
 
 
 def check_net_components(bigip, ifc_num):
+    expected_ifc_names = EXPECTED_IFC_NAMES[:]
+    expected_selfip_names = EXPECTED_SELFIP_NAMES[:]
+    expected_vlan_names = EXPECTED_VLAN_NAMES[:]
     for ifc in range(2, ifc_num):
-        expected_ifc_names = EXPECTED_IFC_NAMES.append('1.{}'.format(ifc))
-        expected_selfip_names = EXPECTED_SELFIP_NAMES.append(
-            u'selfip.network-1.{}'.format(ifc)
-        )
-        expected_vlan_names = EXPECTED_VLAN_NAMES.append(
-            u'network-1.{}'.format(ifc)
-        )
+        expected_ifc_names.append('1.{}'.format(ifc))
+        expected_selfip_names.append(u'selfip.network-1.{}'.format(ifc))
+        expected_vlan_names.append(u'network-1.{}'.format(ifc))
     ifcs = bigip.net.interfaces.get_collection()
     ifc_names = [ifc.name for ifc in ifcs]
     assert sorted(expected_ifc_names) == sorted(ifc_names)

--- a/unsupported/ve/common/bigip_control_security_group.yaml
+++ b/unsupported/ve/common/bigip_control_security_group.yaml
@@ -6,7 +6,6 @@ resources:
 
    bigip_control_security_group:
     type: OS::Neutron::SecurityGroup
-    deletion_policy: Retain
     properties:
       description: security group rules for ha and mirroring self ip address
       name: bigip_control_security_group

--- a/unsupported/ve/common/bigip_data_security_group.yaml
+++ b/unsupported/ve/common/bigip_data_security_group.yaml
@@ -22,3 +22,8 @@ resources:
           direction: ingress
         - protocol: udp
           direction: egress
+
+outputs:
+   data_security_group_id:
+     description: Get resource id of this security group
+     value: { get_resource: bigip_data_security_group }

--- a/unsupported/ve/common/bigip_data_security_group.yaml
+++ b/unsupported/ve/common/bigip_data_security_group.yaml
@@ -6,7 +6,6 @@ resources:
 
    bigip_data_security_group:
     type: OS::Neutron::SecurityGroup
-    deletion_policy: Retain
     properties:
       description: security group rules for data interfaces
       name: bigip_data_security_group

--- a/unsupported/ve/common/bigip_mgmt_security_group.yaml
+++ b/unsupported/ve/common/bigip_mgmt_security_group.yaml
@@ -6,7 +6,6 @@ resources:
 
    bigip_mgmt_security_group:
     type: OS::Neutron::SecurityGroup
-    deletion_policy: Retain
     properties:
       description: security group rules for bigip mgmt port
       name: bigip_mgmt_security_group

--- a/unsupported/ve/common/bigip_mgmt_security_group.yaml
+++ b/unsupported/ve/common/bigip_mgmt_security_group.yaml
@@ -21,5 +21,7 @@ resources:
           port_range_min: 443
           port_range_max: 443
 
-
-
+outputs:
+   mgmt_security_group_id:
+     description: Get resource id of this security group
+     value: { get_resource: bigip_mgmt_security_group }

--- a/unsupported/ve/common/f5_ve_standalone_2_nic.yaml
+++ b/unsupported/ve/common/f5_ve_standalone_2_nic.yaml
@@ -90,26 +90,26 @@ parameter_groups:
   - default_gateway  
 
 resources:
-   mgmt_port:
-     type: OS::Neutron::Port
-     properties:
-       network: {get_param: mgmt_network}
-       security_groups: [{ get_attr: [bigip_mgmt_security_group, mgmt_security_group_id] }]
-   network_1_port:
+  mgmt_port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_param: mgmt_network}
+      security_groups: [{ get_attr: [bigip_mgmt_security_group, mgmt_security_group_id] }]
+  network_1_port:
     type: OS::Neutron::Port
     properties:
       network: {get_param: network_1 }
-      security_groups: [{ get_resource: bigip_data_security_group }]
-   bigip_data_security_group:
-     type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_data_security_group.yaml
-   bigip_mgmt_security_group:
-     type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_mgmt_security_group.yaml
-   floating_ip:
-     type: OS::Neutron::FloatingIP
-     properties:
-       floating_network: { get_param: external_network }
-       port_id: { get_resource: mgmt_port }
-   ve_instance:
+      security_groups: [{ get_attr: [bigip_data_security_group, data_security_group_id] }]
+  bigip_data_security_group:
+    type: https://raw.githubusercontent.com/pjbreaux/f5-openstack-heat-1/bugfix.teardown_glance_images/unsupported/ve/common/bigip_data_security_group.yaml 
+  bigip_mgmt_security_group:
+    type: https://raw.githubusercontent.com/pjbreaux/f5-openstack-heat-1/bugfix.teardown_glance_images/unsupported/ve/common/bigip_mgmt_security_group.yaml 
+  floating_ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: external_network }
+      port_id: { get_resource: mgmt_port }
+  ve_instance:
     type: OS::Nova::Server
     properties:
       image: { get_param: ve_image }
@@ -201,3 +201,6 @@ outputs:
   network_1_port:
     description: The 1.1 port id of f5 VE instance
     value: { get_resource: network_1_port }
+  floating_ip:
+    description: The Floating IP address of the VE
+    value: { get_attr: [floating_ip, floating_ip_address] }

--- a/unsupported/ve/common/f5_ve_standalone_2_nic.yaml
+++ b/unsupported/ve/common/f5_ve_standalone_2_nic.yaml
@@ -112,6 +112,10 @@ parameter_groups:
   - default_gateway  
 
 resources:
+   bigip_data_security_group:
+     type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_data_security_group.yaml
+   bigip_mgmt_security_group:
+     type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_mgmt_security_group.yaml
    mgmt_port:
      type: OS::Neutron::Port
      properties:

--- a/unsupported/ve/common/f5_ve_standalone_2_nic.yaml
+++ b/unsupported/ve/common/f5_ve_standalone_2_nic.yaml
@@ -94,7 +94,7 @@ resources:
      type: OS::Neutron::Port
      properties:
        network: {get_param: mgmt_network}
-       security_groups: [{ get_attr: mgmt_security_group_id }]
+       security_groups: [{ get_attr: [bigip_mgmt_security_group, mgmt_security_group_id] }]
    network_1_port:
     type: OS::Neutron::Port
     properties:

--- a/unsupported/ve/common/f5_ve_standalone_2_nic.yaml
+++ b/unsupported/ve/common/f5_ve_standalone_2_nic.yaml
@@ -37,35 +37,17 @@ parameters:
     label: F5 VE Root User Password
     description: Password used to perform image import services. Can be a hash for a salted password or password phrase.
     hidden: true
-  http_proxy_host:
-    type: string
-    label: HTTP Proxy Host to user to acquire resources
-    default: None
-  http_proxy_port:
-    type: number
-    label: HTTP Proxy Port to use to acquire resources
-    default: 8080
-    constraints:
-      - range: { min: 1024, max: 65534 }
-  http_proxy_script_url:
-    type: string
-    label: HTTP Proxy Script URL for F5 License Client
-    default: None
-  license_activation_host:
-    type: string
-    label: License Activation Host
-    default: None
-  license_activation_port:
-    type: number
-    label: License Activation Port
-    default: 443
-    constraints:
-      - range: { min: 1, max: 65534 }
   license:
     type: string
     label: Primary VE License Base Key
     description: F5 TMOS License Basekey
     hidden: true
+  external_network:
+    type: string
+    label: External Network Name
+    description: External network name where floating IP resides
+    constraints:
+      - custom_constraint: neutron.network
   mgmt_network:
     type: string
     label: VE Management Network
@@ -99,35 +81,34 @@ parameter_groups:
   - admin_password
   - root_password
 - parameters:
-  - http_proxy_host
-  - http_proxy_port
-  - http_proxy_script_url
-  - license_activation_host
-  - license_activation_port
   - license
 - parameters:
+  - external_network
   - mgmt_network
   - network_1
   - network_1_name
   - default_gateway  
 
 resources:
-   bigip_data_security_group:
-     type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_data_security_group.yaml
-   bigip_mgmt_security_group:
-     type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_mgmt_security_group.yaml
    mgmt_port:
      type: OS::Neutron::Port
      properties:
        network: {get_param: mgmt_network}
-       security_groups:
-         - bigip_mgmt_security_group
+       security_groups: [{ get_attr: mgmt_security_group_id }]
    network_1_port:
     type: OS::Neutron::Port
     properties:
       network: {get_param: network_1 }
-      security_groups:
-        - bigip_data_security_group
+      security_groups: [{ get_resource: bigip_data_security_group }]
+   bigip_data_security_group:
+     type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_data_security_group.yaml
+   bigip_mgmt_security_group:
+     type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_mgmt_security_group.yaml
+   floating_ip:
+     type: OS::Neutron::FloatingIP
+     properties:
+       floating_network: { get_param: external_network }
+       port_id: { get_resource: mgmt_port }
    ve_instance:
     type: OS::Nova::Server
     properties:
@@ -142,11 +123,6 @@ resources:
       user_data:
         str_replace:
           params:
-            __http_proxy_host__: { get_param: http_proxy_host }
-            __http_proxy_port__: { get_param: http_proxy_port }
-            __http_proxy_script_url__ : { get_param: http_proxy_script_url }
-            __license_activation_host__: { get_param: license_activation_host }
-            __license_activation_port__: { get_param: license_activation_port }
             __admin_password__: { get_param: admin_password }
             __root_password__: { get_param: root_password }
             __license__: { get_param: license }
@@ -162,11 +138,11 @@ resources:
                    "root_password": "__root_password__",
                    "license": {
                        "basekey": "__license__",
-                       "host": "__license_activation_host__",
-                       "port": "__license_activation_port__",
-                       "proxyhost": "__http_proxy_host__",
-                       "proxyport": "__http_proxy_port__",
-                       "proxyscripturl": "__http_proxy_script_url__"
+                       "host": "None",
+                       "port": "8080",
+                       "proxyhost": "None",
+                       "proxyport": "443",
+                       "proxyscripturl": "None"
                    },
                    "modules": {
                        "auto_provision": "false",

--- a/unsupported/ve/common/f5_ve_standalone_3_nic.yaml
+++ b/unsupported/ve/common/f5_ve_standalone_3_nic.yaml
@@ -103,6 +103,10 @@ parameter_groups:
   - default_gateway  
 
 resources:
+   bigip_data_security_group:
+     type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_data_security_group.yaml
+   bigip_mgmt_security_group:
+     type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_mgmt_security_group.yaml
    floating_ip:
      type: OS::Neutron::FloatingIP
      properties:
@@ -113,13 +117,13 @@ resources:
      properties:
        network: {get_param: mgmt_network}
        security_groups:
-         - bigip_mgmt_security_group
+         - { get_resource: bigip_mgmt_security_group }
    network_1_port:
     type: OS::Neutron::Port
     properties:
       network: {get_param: network_1 }
       security_groups:
-        - bigip_data_security_group
+        - { get_resource: bigip_data_security_group }
    network_2_port:
     type: OS::Neutron::Port
     properties:

--- a/unsupported/ve/common/f5_ve_standalone_3_nic.yaml
+++ b/unsupported/ve/common/f5_ve_standalone_3_nic.yaml
@@ -37,30 +37,6 @@ parameters:
     label: F5 VE Root User Password
     description: Password used to perform image import services
     hidden: true
-  http_proxy_host:
-    type: string
-    label: HTTP Proxy Host to user to acquire resources
-    default: None
-  http_proxy_port:
-    type: number
-    label: HTTP Proxy Port to use to acquire resources
-    default: 8080
-    constraints:
-      - range: { min: 1024, max: 65534 }
-  http_proxy_script_url:
-    type: string
-    label: HTTP Proxy Script URL for F5 License Client
-    default: None
-  license_activation_host:
-    type: string
-    label: License Activation Host
-    default: None
-  license_activation_port:
-    type: number
-    label: License Activation Port
-    default: 443
-    constraints:
-      - range: { min: 1, max: 65534 }
   license:
     type: string
     label: Primary VE License Base Key
@@ -116,11 +92,6 @@ parameter_groups:
   - admin_password
   - root_password
 - parameters:
-  - http_proxy_host
-  - http_proxy_port
-  - http_proxy_script_url
-  - license_activation_host
-  - license_activation_port
   - license
 - parameters:
   - external_network
@@ -170,11 +141,6 @@ resources:
       user_data:
         str_replace:
           params:
-            __http_proxy_host__: { get_param: http_proxy_host }
-            __http_proxy_port__: { get_param: http_proxy_port }
-            __http_proxy_script_url__ : { get_param: http_proxy_script_url }
-            __license_activation_host__: { get_param: license_activation_host }
-            __license_activation_port__: { get_param: license_activation_port }
             __admin_password__: { get_param: admin_password }
             __root_password__: { get_param: root_password }
             __license__: { get_param: license }
@@ -192,11 +158,11 @@ resources:
                    "root_password": "__root_password__",
                    "license": {
                        "basekey": "__license__",
-                       "host": "__license_activation_host__",
-                       "port": "__license_activation_port__",
-                       "proxyhost": "__http_proxy_host__",
-                       "proxyport": "__http_proxy_port__",
-                       "proxyscripturl": "__http_proxy_script_url__"
+                       "host": "None",
+                       "port": "8080",
+                       "proxyhost": "None",
+                       "proxyport": "443",
+                       "proxyscripturl": "None"
                    },
                    "modules": {
                        "auto_provision": "false",

--- a/unsupported/ve/common/f5_ve_standalone_3_nic.yaml
+++ b/unsupported/ve/common/f5_ve_standalone_3_nic.yaml
@@ -103,34 +103,31 @@ parameter_groups:
   - default_gateway  
 
 resources:
-   bigip_data_security_group:
-     type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_data_security_group.yaml
-   bigip_mgmt_security_group:
-     type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_mgmt_security_group.yaml
-   floating_ip:
-     type: OS::Neutron::FloatingIP
-     properties:
-       floating_network: { get_param: external_network }
-       port_id: { get_resource: mgmt_port }
-   mgmt_port:
-     type: OS::Neutron::Port
-     properties:
-       network: {get_param: mgmt_network}
-       security_groups:
-         - { get_resource: bigip_mgmt_security_group }
-   network_1_port:
+  bigip_data_security_group:
+    type: https://raw.githubusercontent.com/pjbreaux/f5-openstack-heat-1/bugfix.teardown_glance_images/unsupported/ve/common/bigip_data_security_group.yaml
+  bigip_mgmt_security_group:
+    type: https://raw.githubusercontent.com/pjbreaux/f5-openstack-heat-1/bugfix.teardown_glance_images/unsupported/ve/common/bigip_mgmt_security_group.yaml
+  mgmt_port:
+    type: OS::Neutron::Port
+    properties:
+      network: {get_param: mgmt_network}
+      security_groups: [{ get_attr: [bigip_mgmt_security_group, mgmt_security_group_id] }]
+  network_1_port:
     type: OS::Neutron::Port
     properties:
       network: {get_param: network_1 }
-      security_groups:
-        - { get_resource: bigip_data_security_group }
-   network_2_port:
+      security_groups: [{ get_attr: [bigip_data_security_group, data_security_group_id] }]
+  floating_ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: external_network }
+      port_id: { get_resource: mgmt_port }
+  network_2_port:
     type: OS::Neutron::Port
     properties:
       network: {get_param: network_2 }
-      security_groups:
-        - bigip_data_security_group
-   ve_instance:
+      security_groups: [{ get_attr: [bigip_data_security_group, data_security_group_id] }]
+  ve_instance:
     type: OS::Nova::Server
     properties:
       image: { get_param: ve_image }


### PR DESCRIPTION
@zancas 

Issues: Issue #53

Problem: When running a functional test for patching a VE image, a user
can provide the '--no-teardown-glance-images' to prevent the removal of
those patched VE images once the test completes. This was not working,
and it was due to a bad setting of the config option.

Analysis: Fixed the config option setting by making the default action
as store true, and the default value of this option as store false.

Tests: Ran the tests both with and without this setting. It works as
expected. Added back in the apt-cache proxy url.