### PR TITLE
Refactor tests to use symbols

### DIFF
--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -19,35 +19,10 @@ import pytest
 
 
 def pytest_addoption(parser):
-    parser.addoption('--bigip-admin-password', action='store',
-                     help='Default BIGIP admin password')
-    parser.addoption('--bigip-root-password', action='store',
-                     help='Default BIGIP root password')
-    parser.addoption('--license', action='store',
-                     help='BIGIP license key')
     parser.addoption('--no-teardown-glance-images', action='store_true',
                      default=False,
                      help='Include if you do not wish to remove images '
                      'pushed into glance.')
-
-
-@pytest.fixture
-def BigIPConfig(request, scope='module'):
-    '''Provides BIGIP password and license configuration.'''
-    admin_password = request.config.getoption('--bigip-admin-password')
-    root_password = request.config.getoption('--bigip-root-password')
-    license = request.config.getoption('license')
-    return admin_password, root_password, license
-
-
-@pytest.fixture
-def OSPassword(request):
-    return request.config.getoption('--os-password')
-
-
-@pytest.fixture
-def AuthAddress(request):
-    return request.config.getoption('--auth-netloc')
 
 
 @pytest.fixture

--- a/test/functional/test_env.yaml
+++ b/test/functional/test_env.yaml
@@ -1,0 +1,14 @@
+---
+bigip_ip: <bigip_ip_address>
+os_tenant_name: <os_tenant_name>
+bigip_admin_password: <bigip_admin_password>
+bigip_root_password: <bigip_root_password>
+os_username: <openstack username>
+os_password: <openstack password>
+os_tenant_id: <openstack_tenant_id>
+auth_netloc: <keystone_ip_address>
+license: <bigip_license>
+auth_url: http://<keystone_ip_address>:5000/v2.0
+heatclient_url: http://<heat_endpoint_ip>:8004/v1/<openstack_tenant_id>
+glanceclient_url: http://<glance_endpoint_ip>:9292
+

--- a/test/functional/ve/images/test_patch_upload_ve_image.py
+++ b/test/functional/ve/images/test_patch_upload_ve_image.py
@@ -50,8 +50,7 @@ def PatchTemplateLoc(SupportedDir):
 def test_patched_image_upload_12_0(
         HeatStack,
         GlanceImageCleanup,
-        OSPassword,
-        AuthAddress,
+        symbols,
         glanceclientmanager,
         PatchTemplateLoc
 ):
@@ -62,13 +61,13 @@ def test_patched_image_upload_12_0(
             'onboard_image': 'ubuntu_14.04_lts',
             'image_prep_key': 'testlab',
             'private_network': 'mgmt_net',
-            'f5_image_import_password': OSPassword,
+            'f5_image_import_password': symbols.os_password,
             'f5_ve_image_url':
             'http://10.190.0.20/~breaux/BIGIP-12.0.0.0.0.606.LTM.qcow2.zip',
             'f5_ve_image_name': BIGIP_12_0_IMG + '.qcow2',
             'apt_cache_proxy_url': 'http://apt-cache.pdbld.f5net.com:3142',
             'f5_image_import_auth_url':
-            'http://{}:5000/v2.0'.format(AuthAddress)
+            'http://{}:5000/v2.0'.format(symbols.auth_netloc)
         }
     )
     assert BIGIP_12_0_IMG in \
@@ -79,8 +78,7 @@ def test_patched_image_upload_12_0(
 def test_patched_image_upload_11_6(
         HeatStack,
         GlanceImageCleanup,
-        OSPassword,
-        AuthAddress,
+        symbols,
         glanceclientmanager,
         PatchTemplateLoc
 ):
@@ -91,13 +89,13 @@ def test_patched_image_upload_11_6(
             'onboard_image': 'ubuntu_14.04_lts',
             'image_prep_key': 'testlab',
             'private_network': 'mgmt_net',
-            'f5_image_import_password': OSPassword,
+            'f5_image_import_password': symbols.os_password,
             'f5_ve_image_url':
             'http://10.190.0.20/~breaux/BIGIP-11.6.0.0.0.401.LTM.qcow2.zip',
             'apt_cache_proxy_url': 'http://apt-cache.pdbld.f5net.com:3142',
             'f5_ve_image_name': BIGIP_11_6_IMG + '.qcow2',
             'f5_image_import_auth_url':
-            'http://{}:5000/v2.0'.format(AuthAddress)
+            'http://{}:5000/v2.0'.format(symbols.auth_netloc)
         }
     )
     assert BIGIP_11_6_IMG in \
@@ -108,8 +106,7 @@ def test_patched_image_upload_11_6(
 def test_patched_image_upload_11_5(
         HeatStack,
         GlanceImageCleanup,
-        OSPassword,
-        AuthAddress,
+        symbols,
         glanceclientmanager,
         PatchTemplateLoc
 ):
@@ -120,13 +117,13 @@ def test_patched_image_upload_11_5(
             'onboard_image': 'ubuntu_14.04_lts',
             'image_prep_key': 'testlab',
             'private_network': 'mgmt_net',
-            'f5_image_import_password': OSPassword,
+            'f5_image_import_password': symbols.os_password,
             'f5_ve_image_url':
             'http://10.190.0.20/~breaux/BIGIP-11.5.4.0.0.256.ALL.qcow2.zip',
             'f5_ve_image_name': BIGIP_11_5_4_IMG + '.qcow2',
             'apt_cache_proxy_url': 'http://apt-cache.pdbld.f5net.com:3142',
             'f5_image_import_auth_url':
-            'http://{}:5000/v2.0'.format(AuthAddress)
+            'http://{}:5000/v2.0'.format(symbols.auth_netloc)
 
         }
     )

--- a/test/functional/ve/standalone/test_f5_base_instance_deploy.py
+++ b/test/functional/ve/standalone/test_f5_base_instance_deploy.py
@@ -93,9 +93,8 @@ def CommonTemplateDir(SupportedDir):
 # These tests require a patched VE instance in your stack
 
 def test_f5_base_instance_deploy_2_nic_11_5_4(
-        HeatStack, BigIPConfig, CommonTemplateDir
+        HeatStack, symbols, CommonTemplateDir
 ):
-    admin_password, root_password, license = BigIPConfig
     hc, stack = HeatStack(
         os.path.join(CommonTemplateDir, 'f5_ve_standalone_2_nic.yaml'),
         'func_test_standalone_2_nic',
@@ -106,23 +105,23 @@ def test_f5_base_instance_deploy_2_nic_11_5_4(
             've_flavor': 'm1.xlarge',
             'network_1': 'data1_net',
             'f5_ve_os_ssh_key': 'testlab',
-            'admin_password': admin_password,
-            'root_password': root_password,
-            'license': license
+            'admin_password': symbols.bigip_admin_password,
+            'root_password': symbols.bigip_root_password,
+            'license': symbols.license
         }
     )
     updated_stack = hc.stacks.get(stack.id)
     floating_ip = get_floating_ip_output(updated_stack)
     bigip = wait_for_active_licensed_bigip(
-        floating_ip, 'admin', admin_password, BIGIP_11_5_4_VERSION, 2
+        floating_ip, 'admin', symbols.bigip_admin_password,
+        BIGIP_11_5_4_VERSION, 2
     )
     check_net_components(bigip, 2)
 
 
 def test_f5_base_instance_deploy_2_nic_11_6(
-        HeatStack, BigIPConfig, CommonTemplateDir
+        HeatStack, symbols, CommonTemplateDir
 ):
-    admin_password, root_password, license = BigIPConfig
     hc, stack = HeatStack(
         os.path.join(CommonTemplateDir, 'f5_ve_standalone_2_nic.yaml'),
         'func_test_standalone_2_nic',
@@ -132,23 +131,23 @@ def test_f5_base_instance_deploy_2_nic_11_6(
             'mgmt_network': 'mgmt_net',
             'network_1': 'data1_net',
             'f5_ve_os_ssh_key': 'testlab',
-            'admin_password': admin_password,
-            'root_password': root_password,
-            'license': license
+            'admin_password': symbols.bigip_admin_password,
+            'root_password': symbols.bigip_root_password,
+            'license': symbols.license
         }
     )
     updated_stack = hc.stacks.get(stack.id)
     floating_ip = get_floating_ip_output(updated_stack)
     bigip = wait_for_active_licensed_bigip(
-        floating_ip, 'admin', admin_password, BIGIP_11_6_VERSION, 2
+        floating_ip, 'admin', symbols.bigip_admin_password,
+        BIGIP_11_6_VERSION, 2
     )
     check_net_components(bigip, 2)
 
 
 def test_f5_base_instance_deploy_2_nic_12_0(
-        HeatStack, BigIPConfig, CommonTemplateDir
+        HeatStack, symbols, CommonTemplateDir
 ):
-    admin_password, root_password, license = BigIPConfig
     hc, stack = HeatStack(
         os.path.join(CommonTemplateDir, 'f5_ve_standalone_2_nic.yaml'),
         'func_test_standalone_2_nic',
@@ -158,23 +157,23 @@ def test_f5_base_instance_deploy_2_nic_12_0(
             'mgmt_network': 'mgmt_net',
             'network_1': 'data1_net',
             'f5_ve_os_ssh_key': 'testlab',
-            'admin_password': admin_password,
-            'root_password': root_password,
-            'license': license
+            'admin_password': symbols.bigip_admin_password,
+            'root_password': symbols.bigip_root_password,
+            'license': symbols.license
         }
     )
     updated_stack = hc.stacks.get(stack.id)
     floating_ip = get_floating_ip_output(updated_stack)
     bigip = wait_for_active_licensed_bigip(
-        floating_ip, 'admin', admin_password, BIGIP_12_0_VERSION, 2
+        floating_ip, 'admin', symbols.bigip_admin_password,
+        BIGIP_12_0_VERSION, 2
     )
     check_net_components(bigip, 2)
 
 
 def test_f5_base_instance_deploy_3_nic_11_5_4(
-        HeatStack, BigIPConfig, CommonTemplateDir
+        HeatStack, symbols, CommonTemplateDir
 ):
-    admin_password, root_password, license = BigIPConfig
     hc, stack = HeatStack(
         os.path.join(CommonTemplateDir, 'f5_ve_standalone_3_nic.yaml'),
         'func_test_standalone_3_nic',
@@ -186,23 +185,23 @@ def test_f5_base_instance_deploy_3_nic_11_5_4(
             'network_1': 'data1_net',
             'network_2': 'data2_net',
             'f5_ve_os_ssh_key': 'testlab',
-            'admin_password': admin_password,
-            'root_password': root_password,
-            'license': license
+            'admin_password': symbols.bigip_admin_password,
+            'root_password': symbols.bigip_root_password,
+            'license': symbols.license
         }
     )
     updated_stack = hc.stacks.get(stack.id)
     floating_ip = get_floating_ip_output(updated_stack)
     bigip = wait_for_active_licensed_bigip(
-        floating_ip, 'admin', admin_password, BIGIP_11_5_4_VERSION, 3
+        floating_ip, 'admin', symbols.bigip_admin_password,
+        BIGIP_11_5_4_VERSION, 3
     )
     check_net_components(bigip, 3)
 
 
 def test_f5_base_instance_deploy_3_nic_11_6(
-        HeatStack, BigIPConfig, CommonTemplateDir
+        HeatStack, symbols, CommonTemplateDir
 ):
-    admin_password, root_password, license = BigIPConfig
     hc, stack = HeatStack(
         os.path.join(CommonTemplateDir, 'f5_ve_standalone_3_nic.yaml'),
         'func_test_standalone_3_nic',
@@ -213,23 +212,23 @@ def test_f5_base_instance_deploy_3_nic_11_6(
             'network_1': 'data1_net',
             'network_2': 'data2_net',
             'f5_ve_os_ssh_key': 'testlab',
-            'admin_password': admin_password,
-            'root_password': root_password,
-            'license': license
+            'admin_password': symbols.bigip_admin_password,
+            'root_password': symbols.bigip_root_password,
+            'license': symbols.license
         }
     )
     updated_stack = hc.stacks.get(stack.id)
     floating_ip = get_floating_ip_output(updated_stack)
     bigip = wait_for_active_licensed_bigip(
-        floating_ip, 'admin', admin_password, BIGIP_11_6_VERSION, 3
+        floating_ip, 'admin', symbols.bigip_admin_password,
+        BIGIP_11_6_VERSION, 3
     )
     check_net_components(bigip, 3)
 
 
 def test_f5_base_instance_deploy_3_nic_12_0(
-        HeatStack, BigIPConfig, CommonTemplateDir
+        HeatStack, symbols, CommonTemplateDir
 ):
-    admin_password, root_password, license = BigIPConfig
     hc, stack = HeatStack(
         os.path.join(CommonTemplateDir, 'f5_ve_standalone_3_nic.yaml'),
         'func_test_standalone_3_nic',
@@ -240,14 +239,15 @@ def test_f5_base_instance_deploy_3_nic_12_0(
             'network_1': 'data1_net',
             'network_2': 'data2_net',
             'f5_ve_os_ssh_key': 'testlab',
-            'admin_password': admin_password,
-            'root_password': root_password,
-            'license': license
+            'admin_password': symbols.bigip_admin_password,
+            'root_password': symbols.bigip_root_password,
+            'license': symbols.license
         }
     )
     updated_stack = hc.stacks.get(stack.id)
     floating_ip = get_floating_ip_output(updated_stack)
     bigip = wait_for_active_licensed_bigip(
-        floating_ip, 'admin', admin_password, BIGIP_12_0_VERSION, 3
+        floating_ip, 'admin', symbols.bigip_admin_password,
+        BIGIP_12_0_VERSION, 3
     )
     check_net_components(bigip, 3)


### PR DESCRIPTION
@szakeri 

Issues:
Fixes #67

Problem:
The test symbols for pytest is now available and ready for use. This
repo's functional tests need updating for using those symbols through
the tests.

Analysis:
Fed the symbols fixture through all tests that require symbols and
removed some of the unnecessary fixtures that were made obsolete by
symbols.

Tests:
Ran functional tests manually. All passed.