### PR TITLE
Add section header to index.rst for intersphinx linking

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,5 @@
+.. _home:
+
 F5 Networks® OpenStack Heat Template Library
 ============================================
 


### PR DESCRIPTION
@pjbreaux -- FYI

Fixes: N/A

#### What's this change do?
add 'home' section header to index.rst for use with intersphinx mapping

#### Where should the reviewer start?
n/a - no review needed

#### Any background context?

We use intersphinx mapping to link between our doc sets using section headers instead of having to hard-code URLs (which can change). I added a section header to the index (or home) page for this repo so I can link to it from f5-openstack-docs.