### PR TITLE
Fixes issue #84 - docs link dead in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ Contributor License Agreement
 Individuals or business entities who contribute to this project must have completed and submitted the `F5® Contributor License Agreement <http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html>`_ to Openstack_CLA@f5.com prior to their code submission being included in this project.
 
 .. |Docs build| image:: http://readthedocs.org/projects/f5-openstack-heat/badge/?version=latest
-    :target: http://f5-openstack-heat.readthedocs.org/en/latest/?badge=latest
+    :target: http://f5-openstack-heat.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
 .. |slack badge| image:: https://f5-openstack-slack.herokuapp.com/badge.svg

--- a/f5_supported/f5_plugins/README.rst
+++ b/f5_supported/f5_plugins/README.rst
@@ -3,4 +3,4 @@ BIG-IP® VE Standalone Templates
 
 The templates in this directory can be used to deploy Heat stacks using the F5® Opestack Heat Plugins.
 
-See the `project documentation <http://f5-openstack-heat.readthedocs.org/en/>`_ for more information.
+See the `project documentation <http://f5-openstack-heat.readthedocs.io>`_ for more information.

--- a/f5_supported/ve/images/README.rst
+++ b/f5_supported/ve/images/README.rst
@@ -5,5 +5,5 @@ Overview
 --------
 The BIG-IP® VE 'OpenStack-Ready' image template makes a BIG-IP® VE image ready for use in OpenStack.
 
-See the `project documentation <http://f5-openstack-heat.readthedocs.org/en/>`_ for more information.
+See the `project documentation <http://f5-openstack-heat.readthedocs.io>`_ for more information.
 

--- a/f5_supported/ve/standalone/README.rst
+++ b/f5_supported/ve/standalone/README.rst
@@ -3,4 +3,4 @@ BIG-IP® VE Standalone Templates
 
 The templates in this directory can be used to deploy varying configurations of standalone BIG-IP® Virtual Editions (VE).
 
-See the `project documentation <http://f5-openstack-heat.readthedocs.org/en/>`_ for more information.
+See the `project documentation <http://f5-openstack-heat.readthedocs.io>`_ for more information.

--- a/unsupported/f5_plugins/README.rst
+++ b/unsupported/f5_plugins/README.rst
@@ -4,5 +4,5 @@ F5® Heat Plugin Example Templates
 Overview
 --------
 
-The ``f5_plugins`` templates use F5® iApps® and Heat templates in tandem to deploy BIG-IP® resources in OpenStack. See the `project documentation <http://f5-openstack-heat.readthedocs.org/en/>`_ for more information.
+The ``f5_plugins`` templates use F5® iApps® and Heat templates in tandem to deploy BIG-IP® resources in OpenStack. See the `project documentation <http://f5-openstack-heat.readthedocs.io>`_ for more information.
 

--- a/unsupported/learning_stacks/README.rst
+++ b/unsupported/learning_stacks/README.rst
@@ -1,7 +1,7 @@
 Learning Stacks
 ===============
 
-If you are just starting out with orchestration in OpenStack, you can use our Learning Stacks template(s) to get an idea of how a Heat stack manages resources. See the `project documentation <http://f5-openstack-heat.readthedocs.org/en/>`_ for more information.
+If you are just starting out with orchestration in OpenStack, you can use our Learning Stacks template(s) to get an idea of how a Heat stack manages resources. See the `project documentation <http://f5-openstack-heat.readthedocs.io>`_ for more information.
 
 
 

--- a/unsupported/ve/README.rst
+++ b/unsupported/ve/README.rst
@@ -5,5 +5,5 @@ VE Templates
 
 The templates within the VE directory can be used to prepare BIG-IP® Virtual Edition (VE) images for use and to launch VE in OpenStack clouds.
 
-See the `project documentation <http://f5-openstack-heat.readthedocs.org/en/>`_ for more information.
+See the `project documentation <http://f5-openstack-heat.readthedocs.io>`_ for more information.
 

--- a/unsupported/ve/common/README.rst
+++ b/unsupported/ve/common/README.rst
@@ -3,4 +3,4 @@ BIG-IP® VE Common Template Resources
 
 The templates in this directory are often used by other templates to compose a customized stack.
 
-See the `project documentation <http://f5-openstack-heat.readthedocs.org/en/>`_ for more information.
+See the `project documentation <http://f5-openstack-heat.readthedocs.io>`_ for more information.

--- a/unsupported/ve/images/README.rst
+++ b/unsupported/ve/images/README.rst
@@ -3,5 +3,5 @@ OpenStack-Ready BIG-IP® VE Images
 
 The BIG-IP® VE 'OpenStack-Ready' image template makes a BIG-IP® VE image ready for use in OpenStack.
 
-See the `project documentation <http://f5-openstack-heat.readthedocs.org/en/>`_ for more information.
+See the `project documentation <http://f5-openstack-heat.readthedocs.io>`_ for more information.
 

--- a/unsupported/ve/standalone/README.rst
+++ b/unsupported/ve/standalone/README.rst
@@ -3,4 +3,4 @@ BIG-IP® VE Standalone Templates
 
 The BIG-IP® VE Standalone templates deploy a single VE instance, with variations on the number of desired data interfaces.
 
-See the `project documentation <http://f5-openstack-heat.readthedocs.org/en/>`_ for more information.
+See the `project documentation <http://f5-openstack-heat.readthedocs.io>`_ for more information.


### PR DESCRIPTION
@pjbreaux @andrewjjenkins 

Fixes #84 

All instances of the old dead link have been updated with the new Read the Docs URL.