### PR TITLE
Fix references to sub-templates in parent templates to not point at development

### DIFF
--- a/f5_supported/ve/resource_group/f5_two_ve_resource_group.yaml
+++ b/f5_supported/ve/resource_group/f5_two_ve_resource_group.yaml
@@ -121,7 +121,7 @@ resources:
     properties:
       count: 2
       resource_def:
-        type: https://raw.githubusercontent.com/pjbreaux/f5-openstack-heat-1/feature.cluster/f5_supported/ve/common/cluster_ready_ve_4_nic.yaml
+        type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/kilo/f5_supported/ve/common/cluster_ready_ve_4_nic.yaml
         properties:
           ve_image: { get_param: ve_image }
           ve_flavor: { get_param: ve_flavor }

--- a/f5_supported/ve/standalone/f5_ve_standalone_2_nic.yaml
+++ b/f5_supported/ve/standalone/f5_ve_standalone_2_nic.yaml
@@ -101,9 +101,9 @@ resources:
       network: {get_param: network_1 }
       security_groups: [{ get_attr: [bigip_data_security_group, data_security_group_id] }]
   bigip_data_security_group:
-    type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_data_security_group.yaml
+    type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/kilo/unsupported/ve/common/bigip_data_security_group.yaml
   bigip_mgmt_security_group:
-    type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_mgmt_security_group.yaml
+    type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/kilo/unsupported/ve/common/bigip_mgmt_security_group.yaml
   floating_ip:
     type: OS::Neutron::FloatingIP
     properties:

--- a/f5_supported/ve/standalone/f5_ve_standalone_3_nic.yaml
+++ b/f5_supported/ve/standalone/f5_ve_standalone_3_nic.yaml
@@ -104,9 +104,9 @@ parameter_groups:
 
 resources:
   bigip_data_security_group:
-    type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_data_security_group.yaml
+    type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/kilo/unsupported/ve/common/bigip_data_security_group.yaml
   bigip_mgmt_security_group:
-    type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/develop/unsupported/ve/common/bigip_mgmt_security_group.yaml
+    type: https://raw.githubusercontent.com/F5Networks/f5-openstack-heat/kilo/unsupported/ve/common/bigip_mgmt_security_group.yaml
   mgmt_port:
     type: OS::Neutron::Port
     properties:


### PR DESCRIPTION
Issues:
Fixes #90

Problem:
In the kilo branch, the references to sub-templates should refer to
other templates in the kilo branch on github.

Analysis:
Fixed the references.

Tests:
Tests all pass