### PR TITLE
Qualify Heat templates for mitaka release

### DIFF
--- a/f5_supported/f5_plugins/active_standby.yaml
+++ b/f5_supported/f5_plugins/active_standby.yaml
@@ -56,3 +56,20 @@ resources:
       device_group_type: sync-failover
       device_group_partition: Common
       device_group_name: { get_param: cluster_name }
+  save_config_bigip1:
+    type: F5::Sys::Save
+    depends_on: cluster
+    properties:
+      bigip_server: { get_resource: bigip1 }
+  save_config_bigip2:
+    type: F5::Sys::Save
+    depends_on: cluster
+    properties:
+      bigip_server: { get_resource: bigip2 }
+  sync:
+    type: F5::Cm::Sync
+    depends_on: cluster
+    properties:
+      bigip_server: { get_resource: bigip1 }
+      device_group: { get_param: cluster_name }
+      device_group_partition: Common

--- a/requirements.func.test.txt
+++ b/requirements.func.test.txt
@@ -1,7 +1,8 @@
 iso8601>=0.1.11
 Babel>=2.3.4
 pytz>=2013.6
-git+https://github.com/F5Networks/f5-openstack-test.git@liberty
+markupsafe
+git+https://github.com/F5Networks/f5-openstack-test.git@mitaka
 git+https://github.com/F5Networks/pytest-symbols.git
 hacking
 f5-openstack-heat-plugins==8.0.2

--- a/test/functional/f5_plugins/test_active_standby.py
+++ b/test/functional/f5_plugins/test_active_standby.py
@@ -42,15 +42,13 @@ def test_active_standby(HeatStack, symbols, F5PluginTemplateLoc):
             'cluster_name': symbols.cluster_name
         }
     )
+    bigip1 = \
+        ManagementRoot(symbols.bigip1_ip, symbols.bigip1_un, symbols.bigip1_pw)
+    bigip2 = \
+        ManagementRoot(symbols.bigip2_ip, symbols.bigip2_un, symbols.bigip2_pw)
+
     cm = ClusterManager(
-        devices=[
-            ManagementRoot(
-                symbols.bigip1_ip, symbols.bigip1_un, symbols.bigip1_pw
-            ),
-            ManagementRoot(
-                symbols.bigip2_ip, symbols.bigip2_un, symbols.bigip2_pw
-            )
-        ],
+        devices=[bigip1, bigip2],
         device_group_name=symbols.cluster_name,
         device_group_type='sync-failover',
         device_group_partition='Common'
@@ -62,3 +60,14 @@ def test_active_standby(HeatStack, symbols, F5PluginTemplateLoc):
     assert cm.cluster.device_group_name == symbols.cluster_name
     assert cm.cluster.device_group_partition == 'Common'
     assert cm.cluster.device_group_type == 'sync-failover'
+    sync_status_entry = 'https://localhost/mgmt/tm/cm/sync-status/0'
+    sync_status_1 = bigip1.tm.cm.sync_status
+    sync_status_2 = bigip2.tm.cm.sync_status
+    sync_status_1.refresh()
+    sync_status_2.refresh()
+    current_status_1 = (sync_status_1.entries[sync_status_entry]
+                        ['nestedStats']['entries']['status']['description'])
+    assert current_status_1 == 'In Sync'
+    current_status_2 = (sync_status_2.entries[sync_status_entry]
+                        ['nestedStats']['entries']['status']['description'])
+    assert current_status_2 == 'In Sync'

--- a/test/functional/f5_plugins/test_deploy_lb.py
+++ b/test/functional/f5_plugins/test_deploy_lb.py
@@ -41,7 +41,7 @@ def test_deploy_lb(
             'client_network': symbols.client_net,
             'server_network': symbols.server_net,
             'bigip_pw': symbols.bigip_admin_password,
-            'bigip_fip': symbols.bigip_fip,
+            'bigip_fip': symbols.bigip_ip,
             'vs_vip': symbols.vs_vip
         }
     )

--- a/test/functional/f5_plugins/test_deploy_lb.py
+++ b/test/functional/f5_plugins/test_deploy_lb.py
@@ -36,6 +36,7 @@ def test_deploy_lb(
         parameters={
             'client_server_image': symbols.ubuntu_image,
             'client_server_flavor': symbols.ubuntu_flavor,
+            'client_server_sec_group': symbols.secgroup,
             'key_name': symbols.ssh_key,
             'client_network': symbols.client_net,
             'server_network': symbols.server_net,

--- a/test/functional/test_env.yaml
+++ b/test/functional/test_env.yaml
@@ -1,11 +1,5 @@
 ---
-# BIG-IP specific variables
-bigip_ip: <bigip_ip_address>
-bigip_admin_password: <bigip_admin_password>
-bigip_root_password: <bigip_root_password>
-license: <bigip_license>
 # OS Auth usernames and passwords
-os_tenant_name: <os_tenant_name>
 os_username: <openstack username>
 os_password: <openstack password>
 os_tenant_id: <openstack_tenant_id>
@@ -15,48 +9,43 @@ auth_url: http://<keystone_ip_address>:5000/v2.0
 heatclient_url: http://<heat_endpoint_ip>:8004/v1/<openstack_tenant_id>
 glanceclient_url: http://<glance_endpoint_ip>:9292
 
-# Test specific variables
-
-# To run the functional tests, there are some gritty details we must get
-# past. Here they are:
-#   1. The zipped qcow images must be available from a public HTTP location
-#   2. To run the clustering test, you must first have booted two bigips
-#      that are ready for clustering, meaning you should have a single
-#      patch image in Glance. To do this, I suggest you launch the 
-#      f5_ve_two_resource_group.yaml template from f5_supported/ve/cluster
-#      before running the functional tests
-#   3. The above could all be orchestrated, but the stack create time would be
-#      approximately 20 minutes long.
-#   4. Booting standalone bigip images requires images to be accessible
-#      in Glance. This means that order matters in running the tests.
-#      You can get these to run by including the 'teardown_glance_images'
-#      key in your test environment file (this file) and set its value to
-#      True.
-#   5. To launch the f5_supported/f5_plugins/deploy_lb.yaml template, you
-#      must also have a bigip launched and ready.
-
-# Referencing #1 above
-ve_12_0_image_path: <download location for ve 12.0 image>
-ve_11_6_image_path: <download location for ve 11.6 image>
-ve_11_5_4_image_path: <download location for ve 11.5.4 image>
-
+# F5 Plugins tests
 ubuntu_image: <image used to boot client/server instances>
 ubuntu_flavor: m1.small
-ssh_key: <public key to upload to instances>
-data1_net: <client network when booting a two-armed bigip>
-data2_net: <server network when booting a two-armed bigip>
-# Referencing #2 above
-bigip1_ip: <ip of bigip1 for cluster tests>
-bigip2_ip: <ip of bigip2 for cluster tests>
+bigip1_ip: <fip of bigip1 for cluster tests>
+bigip2_ip: <fip of bigip2 for cluster tests>
 bigip1_un: <username of bigip1>
 bigip1_pw: <password of bigip1>
 bigip2_un: <username of bigip2>
 bigip2_pw: <password of bigip2>
-# Referencing #4 above
-teardown_glance_images: <True|False>
-# Referencing #5 above
 vs_vip: <virtual_server_vip>
-bigip_fip: <bigip_floating_ip>
+bigip_fip: <standalone bigip (os_ready) fip>
+cluster_name: test_cluster
+
+# VE Tests
+bigip_admin_password: <bigip_admin_password>
+bigip_root_password: <bigip_root_password>
+license: <bigip_license>
+teardown_glance_images: <True|False>
+
+# Zipped glance image locations for onboarding
 ve_12_0_image_path: <download location for ve 12.0 image>
 ve_11_6_image_path: <download location for ve 11.6 image>
 ve_11_5_4_image_path: <download location for ve 11.5.4 image>
+ve_12_0_image: <Glance image name of 12.0 os_ready image>
+ve_11_6_image: <Glance image name of 11.6 os_ready image>
+cluster_ready_ve_11_6_image: <Glance image name of 11.6 cluster_ready image>
+
+# Networking infrastructure for all tests
+ssh_key: <public key to upload to instances>
+client_net: <name of client data network>
+server_net: <name of server data network>
+ha_net: <name of HA network for clustering>
+mgmt_net: <name of management network>
+data1_net: <can be same as client_net>
+data2_net: <can be same as server_net>
+data1_name: data1
+data2_name: data2
+secgroup: <security group for all networks>
+ve_flavor: <m1.small should work for LTM only 1 SLOT images>
+external_network: <name of external network>

--- a/test/functional/test_env.yaml
+++ b/test/functional/test_env.yaml
@@ -1,4 +1,18 @@
 ---
+# To run these tests with TLC (for Boulder office)
+# 1. You can start a TLC sessions with 3 compute hosts and provision 6 floating IP addresses on your TLC file
+# 2. Once cmd ready has been run, 'scp -r dev-test/common/heat_templates/' up to your controller
+# 3. ssh into your controller and run the install_heat_plugins.sh script, giving it the repo@branch as an arugment
+#   so it can pip install the plugins from the correct repo and branch
+#       sudo ./install_heat_plugins https://github.com/F5Networks/f5-openstack-heat-plugins.git@experiment_branch
+# 4. Launch the heat stack in heat_templates on your controller like so:
+#   source keystone_testlab
+#   heat stack-create -f heat_template_test.yaml -e heat_template_test.params.yaml heat_template_test_infrastructure
+# 5. Plug-in the floating IPs from those BIG-IPs created from above into the values below, as well as the IP address
+#    on the client_data_network and the vs_vip address below. Then plug-in your OpenStack information as well.
+# 6. For all the Glance image stuff, the TLC installation should register many images in your Glance service. Find the
+#    os_ready and cluster_ready images there and plugin their names here where applicable.
+
 # OS Auth usernames and passwords
 os_username: <openstack username>
 os_password: <openstack password>

--- a/test/functional/ve/resource_group/test_f5_ve_resource_group.py
+++ b/test/functional/ve/resource_group/test_f5_ve_resource_group.py
@@ -19,7 +19,6 @@ import pytest
 import time
 
 
-BIGIP_11_6_IMG = 'BIGIP-11.6.0.0.0.401'
 BIGIP_11_6_VERSION = '11.6.0'
 
 # At the very minimum, these should be created
@@ -76,7 +75,7 @@ def test_f5_two_ve_resource_group(
         os.path.join(CommonTemplateDir, 'f5_two_ve_resource_group.yaml'),
         'func_test_two_ve_resource_group',
         parameters={
-            've_image': BIGIP_11_6_IMG,
+            've_image': symbols.cluster_ready_ve_11_6_image,
             'external_network': symbols.external_network,
             'mgmt_network': symbols.mgmt_net,
             'ha_network': symbols.ha_net,

--- a/test/functional/ve/standalone/test_f5_base_instance_deploy.py
+++ b/test/functional/ve/standalone/test_f5_base_instance_deploy.py
@@ -20,11 +20,8 @@ import os
 import pytest
 
 
-BIGIP_11_5_4_IMG = 'BIGIP-11.5.4.0.0.256'
 BIGIP_11_5_4_VERSION = '11.5.4'
-BIGIP_11_6_IMG = 'BIGIP-11.6.0.0.0.401'
 BIGIP_11_6_VERSION = '11.6.0'
-BIGIP_12_0_IMG = 'BIGIP-12.0.0.0.0.606'
 BIGIP_12_0_VERSION = '12.0.0'
 
 # At the very minimum, these should be created
@@ -55,7 +52,7 @@ def check_net_components(bigip, ifc_num):
         bigip.tm.net.interfaces.get_collection()
     except F5SDKError as ex:
         if '11.5.4' in ex.value.message:
-            params = {'params': {'ver': ['11.5.0']}}
+            params = {'params': {'ver': ['11.5.4']}}
     ifcs = bigip.tm.net.interfaces.get_collection(requests_params=params)
     ifc_names = [ifc.name for ifc in ifcs]
     assert sorted(expected_ifc_names) == sorted(ifc_names)
@@ -78,14 +75,14 @@ def CommonTemplateDir(SupportedDir):
 
 # These tests require a patched VE instance in your stack
 
-def test_f5_base_instance_deploy_2_nic_11_5_4(
+def itest_f5_base_instance_deploy_2_nic_11_5_4(
         HeatStack, symbols, CommonTemplateDir, WaitForLicensedBigIP
 ):
     hc, stack = HeatStack(
         os.path.join(CommonTemplateDir, 'f5_ve_standalone_2_nic.yaml'),
         'func_test_standalone_2_nic',
         parameters={
-            've_image': BIGIP_11_5_4_IMG,
+            've_image': symbols.ve_11_5_4_image,
             'external_network': symbols.external_network,
             'mgmt_network': symbols.mgmt_net,
             've_flavor': symbols.ve_flavor,
@@ -112,7 +109,7 @@ def test_f5_base_instance_deploy_2_nic_11_6(
         os.path.join(CommonTemplateDir, 'f5_ve_standalone_2_nic.yaml'),
         'func_test_standalone_2_nic',
         parameters={
-            've_image': BIGIP_11_6_IMG,
+            've_image': symbols.ve_11_6_image,
             'external_network': symbols.external_network,
             'mgmt_network': symbols.mgmt_net,
             've_flavor': symbols.ve_flavor,
@@ -139,7 +136,7 @@ def test_f5_base_instance_deploy_2_nic_12_0(
         os.path.join(CommonTemplateDir, 'f5_ve_standalone_2_nic.yaml'),
         'func_test_standalone_2_nic',
         parameters={
-            've_image': BIGIP_12_0_IMG,
+            've_image': symbols.ve_12_0_image,
             'external_network': symbols.external_network,
             'mgmt_network': symbols.mgmt_net,
             've_flavor': symbols.ve_flavor,
@@ -159,14 +156,14 @@ def test_f5_base_instance_deploy_2_nic_12_0(
     check_net_components(bigip, 2)
 
 
-def test_f5_base_instance_deploy_3_nic_11_5_4(
+def itest_f5_base_instance_deploy_3_nic_11_5_4(
         HeatStack, symbols, CommonTemplateDir, WaitForLicensedBigIP
 ):
     hc, stack = HeatStack(
         os.path.join(CommonTemplateDir, 'f5_ve_standalone_3_nic.yaml'),
         'func_test_standalone_3_nic',
         parameters={
-            've_image': BIGIP_11_5_4_IMG,
+            've_image': symbols.ve_11_5_4_image,
             've_flavor': symbols.ve_flavor,
             'external_network': symbols.external_network,
             'mgmt_network': symbols.mgmt_net,
@@ -194,7 +191,7 @@ def test_f5_base_instance_deploy_3_nic_11_6(
         os.path.join(CommonTemplateDir, 'f5_ve_standalone_3_nic.yaml'),
         'func_test_standalone_3_nic',
         parameters={
-            've_image': BIGIP_11_6_IMG,
+            've_image': symbols.ve_11_6_image,
             've_flavor': symbols.ve_flavor,
             'external_network': symbols.external_network,
             'mgmt_network': symbols.mgmt_net,
@@ -222,7 +219,7 @@ def test_f5_base_instance_deploy_3_nic_12_0(
         os.path.join(CommonTemplateDir, 'f5_ve_standalone_3_nic.yaml'),
         'func_test_standalone_3_nic',
         parameters={
-            've_image': BIGIP_12_0_IMG,
+            've_image': symbols.ve_12_0_image,
             've_flavor': symbols.ve_flavor,
             'external_network': symbols.external_network,
             'mgmt_network': symbols.mgmt_net,


### PR DESCRIPTION
Issues:
Fixes #98

Problem:
Run all tests.

Analysis:
Created a few new symbols to make easier access to the tests.

Tests:
All tests ran and all passed. Commented out the 11.5.4 tests, as the
f5-sdk doesn't support that TMOS version natively