### PR TITLE
Add tests for save and sync plugins

### DIFF
--- a/f5_supported/f5_plugins/active_standby.yaml
+++ b/f5_supported/f5_plugins/active_standby.yaml
@@ -56,3 +56,20 @@ resources:
       device_group_type: sync-failover
       device_group_partition: Common
       device_group_name: { get_param: cluster_name }
+  save_config_bigip1:
+    type: F5::Sys::Save
+    depends_on: cluster
+    properties:
+      bigip_server: { get_resource: bigip1 }
+  save_config_bigip2:
+    type: F5::Sys::Save
+    depends_on: cluster
+    properties:
+      bigip_server: { get_resource: bigip2 }
+  sync:
+    type: F5::Cm::Sync
+    depends_on: cluster
+    properties:
+      bigip_server: { get_resource: bigip1 }
+      device_group: { get_param: cluster_name }
+      device_group_partition: Common

--- a/test/functional/f5_plugins/test_active_standby.py
+++ b/test/functional/f5_plugins/test_active_standby.py
@@ -42,11 +42,13 @@ def test_active_standby(HeatStack, symbols, F5PluginTemplateLoc):
             'cluster_name': symbols.cluster_name
         }
     )
-    a = ManagementRoot(symbols.bigip1_ip, symbols.bigip1_un, symbols.bigip1_pw)
-    b = ManagementRoot(symbols.bigip2_ip, symbols.bigip2_un, symbols.bigip2_pw)
+    bigip1 = \
+        ManagementRoot(symbols.bigip1_ip, symbols.bigip1_un, symbols.bigip1_pw)
+    bigip2 = \
+        ManagementRoot(symbols.bigip2_ip, symbols.bigip2_un, symbols.bigip2_pw)
 
     cm = ClusterManager(
-        devices=[a, b],
+        devices=[bigip1, bigip2],
         device_group_name=symbols.cluster_name,
         device_group_type='sync-failover',
         device_group_partition='Common'
@@ -59,13 +61,13 @@ def test_active_standby(HeatStack, symbols, F5PluginTemplateLoc):
     assert cm.cluster.device_group_partition == 'Common'
     assert cm.cluster.device_group_type == 'sync-failover'
     sync_status_entry = 'https://localhost/mgmt/tm/cm/sync-status/0'
-    sync_status_a = a.tm.cm.sync_status
-    sync_status_b = b.tm.cm.sync_status
-    sync_status_a.refresh()
-    sync_status_b.refresh()
-    current_status_a = (sync_status_a.entries[sync_status_entry]
+    sync_status_1 = bigip1.tm.cm.sync_status
+    sync_status_2 = bigip2.tm.cm.sync_status
+    sync_status_1.refresh()
+    sync_status_2.refresh()
+    current_status_1 = (sync_status_1.entries[sync_status_entry]
                         ['nestedStats']['entries']['status']['description'])
-    assert current_status_a == 'In Sync'
-    current_status_b = (sync_status_b.entries[sync_status_entry]
+    assert current_status_1 == 'In Sync'
+    current_status_2 = (sync_status_2.entries[sync_status_entry]
                         ['nestedStats']['entries']['status']['description'])
-    assert current_status_b == 'In Sync'
+    assert current_status_2 == 'In Sync'

--- a/test/functional/f5_plugins/test_deploy_lb.py
+++ b/test/functional/f5_plugins/test_deploy_lb.py
@@ -41,7 +41,7 @@ def test_deploy_lb(
             'client_network': symbols.client_net,
             'server_network': symbols.server_net,
             'bigip_pw': symbols.bigip_admin_password,
-            'bigip_fip': symbols.bigip_fip,
+            'bigip_fip': symbols.bigip_ip,
             'vs_vip': symbols.vs_vip
         }
     )

--- a/test/functional/test_env.yaml
+++ b/test/functional/test_env.yaml
@@ -1,4 +1,18 @@
 ---
+# To run these tests with TLC (for Boulder office)
+# 1. You can start a TLC sessions with 3 compute hosts and provision 6 floating IP addresses on your TLC file
+# 2. Once cmd ready has been run, 'scp -r dev-test/common/heat_templates/' up to your controller
+# 3. ssh into your controller and run the install_heat_plugins.sh script, giving it the repo@branch as an arugment
+#   so it can pip install the plugins from the correct repo and branch
+#       sudo ./install_heat_plugins https://github.com/F5Networks/f5-openstack-heat-plugins.git@experiment_branch
+# 4. Launch the heat stack in heat_templates on your controller like so:
+#   source keystone_testlab
+#   heat stack-create -f heat_template_test.yaml -e heat_template_test.params.yaml heat_template_test_infrastructure
+# 5. Plug-in the floating IPs from those BIG-IPs created from above into the values below, as well as the IP address
+#    on the client_data_network and the vs_vip address below. Then plug-in your OpenStack information as well.
+# 6. For all the Glance image stuff, the TLC installation should register many images in your Glance service. Find the
+#    os_ready and cluster_ready images there and plugin their names here where applicable.
+
 # OS Auth usernames and passwords
 os_username: <openstack username>
 os_password: <openstack password>


### PR DESCRIPTION
@szakeri 

Issues:
Fixes #102

Problem:
New plugins are being added to f5-openstack-heat-plugins for
F5::Sys::Save and F5::Cm::Sync and they need to be added to an
f5_supported template for testing.

Analysis:
Added use of plugins in active_standby template to save config on both
devices and sync config on one device to the group.

Tests:
All tests pass