### PR TITLE
Setting release in docs/conf.py to correct version for liberty.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ version = "8.0.1"
 release = "8.0.1"
 
 # OpenStack release
-openstack_release = "Liberty"
+openstack_release = "liberty"
 
 rst_epilog = """
 .. |openstack| replace:: {0}

--- a/version.py
+++ b/version.py
@@ -15,5 +15,5 @@
 # After release remove the pre-release strings
 # Maintenance release bumps patch version (last number)
 # New template bumps minor version
-VERSION = u'1.0.1.alpha.1'
-OPENSTACK_RELEASE = u'kilo'
+VERSION = u'8.0.1'
+OPENSTACK_RELEASE = u'liberty'


### PR DESCRIPTION
#### What's this change do?
Setting release in the appropriate places for liberty release 8.0.1

#### Any background context?

#### Where should the reviewer start?