### PR TITLE
Fixes #118 - add section tags for easy referencing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -301,7 +301,7 @@ texinfo_documents = [
 
 # intersphinx mapping to other F5 openstack docs
 intersphinx_mapping = {'docs': (
-    'http://f5-openstack-docs.readthedocs.io/en/1.0', None),
+    'http://f5-openstack-docs.readthedocs.io/en/kilo', None),
     'heatplugins': (
     'http://f5-openstack-heat-plugins.readthedocs.io/en/kilo', None),
     }

--- a/docs/includes/concept_f5-bigip-ve-templates.rst
+++ b/docs/includes/concept_f5-bigip-ve-templates.rst
@@ -2,13 +2,13 @@
 
 .. _ve_home:
 
-F5® BIG-IP® VE Templates
+F5 BIG-IP VE Templates
 ========================
 
 Overview
 --------
 
-The templates within the VE directory can be used to prepare BIG-IP® Virtual Edition (VE) images for use and to launch VE in OpenStack clouds.
+The templates within the VE directory can be used to prepare BIG-IP Virtual Edition (VE) images for use and to launch VE in OpenStack clouds.
 
 .. toctree::
     :titlesonly:

--- a/docs/includes/concept_f5-iapps-plugins.rst
+++ b/docs/includes/concept_f5-iapps-plugins.rst
@@ -2,36 +2,36 @@
 
 .. _f5-heat-plugins:
 
-F5® Heat Plugin Example Templates
+F5 Heat Plugin Example Templates
 =================================
 
 Before You Start
 ----------------
 
-The ``f5_plugins`` templates require the F5® Heat plugins found in `F5Networks/f5-openstack-heat-plugins <https://github.com/F5Networks/f5-openstack-heat-plugins>`_. See the :ref:`project documentation <heatplugins:home>` for installation instructions.
+The ``f5_plugins`` templates require the F5 Heat plugins found in `F5Networks/f5-openstack-heat-plugins <https://github.com/F5Networks/f5-openstack-heat-plugins>`_. See the :ref:`project documentation <heatplugins:home>` for installation instructions.
 
 Overview
 --------
-The ``f5_plugins`` templates use F5® iApps® and Heat templates in tandem to deploy BIG-IP® resources in OpenStack. F5®'s iApps® contain specific configuration deployments, represented as executable TCL scripts. Each of these scripts is called an iApps® template.
+The ``f5_plugins`` templates use F5 iApps and Heat templates in tandem to deploy BIG-IP resources in OpenStack. F5's iApps contain specific configuration deployments, represented as executable TCL scripts. Each of these scripts is called an iApps template.
 
-There are two ways to use F5®'s Heat plugins to deploy iApps® templates. The first, demonstrated in :file:`deploy_composite_iapp.yaml` and :file:`F5::Sys::iAppCompositeTemplate`, combines Heat and iApps® templates to create an iApps® service on a BIG-IP®.
+There are two ways to use F5's Heat plugins to deploy iApps templates. The first, demonstrated in :file:`deploy_composite_iapp.yaml` and :file:`F5::Sys::iAppCompositeTemplate`, combines Heat and iApps templates to create an iApps service on a BIG-IP.
 
-The second method is a simple dump of the iApp®'s full TCL file into the Heat template, as we've done in :file:`F5::Sys::iAppFullTemplate`. Once the template has been created on the BIG-IP®, it can be executed to create the iApp® Service (``F5::Sys::iAppService``).
+The second method is a simple dump of the iApp's full TCL file into the Heat template, as we've done in :file:`F5::Sys::iAppFullTemplate`. Once the template has been created on the BIG-IP, it can be executed to create the iApp Service (``F5::Sys::iAppService``).
 
-We've provided example templates for each supported F5® plugin. Feel free to browse around the repo (`F5Networks/f5-openstack-heat/unsupported/f5_plugins <https://github.com/F5Networks/f5-openstack-heat/tree/kilo/unsupported/f5_plugins>`_); you can fork the project and tweak the parameters and resources to suit your needs.
+We've provided example templates for each supported F5 plugin. Feel free to browse around the repo (`F5Networks/f5-openstack-heat/unsupported/f5_plugins <https://github.com/F5Networks/f5-openstack-heat/tree/kilo/unsupported/f5_plugins>`_); you can fork the project and tweak the parameters and resources to suit your needs.
 
 
-iApps® APIC Integration Template
+iApps APIC Integration Template
 --------------------------------
 
-This Heat template deploys an iApps® template that can automate and orchestrate Layer 4-7 applications service deployments using F5® BIG-IP®/BIG-IQ® products. Additionally, it can serve as a common integration point for third party SDN/NFV/Automation/Orchestration products.
+This Heat template deploys an iApps template that can automate and orchestrate Layer 4-7 applications service deployments using F5 BIG-IP/BIG-IQ products. Additionally, it can serve as a common integration point for third party SDN/NFV/Automation/Orchestration products.
 
-There are two major components to this deployment. The iApps® template deploys first, then the Heat template creates the service.  When the service is deployed, the Heat template passes in a set of default answers to the choices/questions posed in the APL section of the iApps® template. These answers, which can be in the form of variables, tables, and/or lists, can be altered as needed to suit your needs.
+There are two major components to this deployment. The iApps template deploys first, then the Heat template creates the service.  When the service is deployed, the Heat template passes in a set of default answers to the choices/questions posed in the APL section of the iApps template. These answers, which can be in the form of variables, tables, and/or lists, can be altered as needed to suit your needs.
 
-For more information about this iApp® and its author, please see `appsvcs_integration_iapp <https://github.com/0xHiteshPatel/appsvcs_integration_iapp>`_ on GitHub.
+For more information about this iApp and its author, please see `appsvcs_integration_iapp <https://github.com/0xHiteshPatel/appsvcs_integration_iapp>`_ on GitHub.
 
 Heat Composition
 ----------------
 
-These templates are examples of how to perform Heat template composition. This is not the only way to do Heat template composition. Refer to the `Openstack Template Composition <http://docs.openstack.org/developer/heat/template_guide/composition.html>` for more information on this way to compose Heat templates. These are specifically using composition and the F5® Heat plugins to stand up a load-balancing scenario. The client issues a curl request to the virtual IP address, and that request is proxied to the backend pool member. Both the client and the server are created in the template, but the underlying private networks they connect to are not. The other important note is that the VE itself is not created in these templates, we are merely interacting with an existing VE.
+These templates are examples of how to perform Heat template composition. This is not the only way to do Heat template composition. Refer to the `Openstack Template Composition <http://docs.openstack.org/developer/heat/template_guide/composition.html>` for more information on this way to compose Heat templates. These are specifically using composition and the F5 Heat plugins to stand up a load-balancing scenario. The client issues a curl request to the virtual IP address, and that request is proxied to the backend pool member. Both the client and the server are created in the template, but the underlying private networks they connect to are not. The other important note is that the VE itself is not created in these templates, we are merely interacting with an existing VE.
 

--- a/docs/includes/concept_ve-common.rst
+++ b/docs/includes/concept_ve-common.rst
@@ -2,7 +2,7 @@
 
 .. _ve-common:
 
-BIG-IP® VE Common Template Resources
+BIG-IP VE Common Template Resources
 ====================================
 
 Overview

--- a/docs/includes/concept_ve-images.rst
+++ b/docs/includes/concept_ve-images.rst
@@ -1,15 +1,15 @@
 :orphan: true
 
-OpenStack-Ready BIG-IP® VE Images
+OpenStack-Ready BIG-IP VE Images
 =================================
 
 Overview
 --------
-The BIG-IP® VE 'OpenStack-Ready' image template(s) can be used to prepare a BIG-IP® VE image for use in OpenStack. The :file:`patch_upload_ve_image.yaml` template launches an Ubuntu server that downloads a zipped F5® BIG-IP® VE qcow image, extracts it, and patches it.
+The BIG-IP VE 'OpenStack-Ready' image template(s) can be used to prepare a BIG-IP VE image for use in OpenStack. The :file:`patch_upload_ve_image.yaml` template launches an Ubuntu server that downloads a zipped F5 BIG-IP VE qcow image, extracts it, and patches it.
 
 .. note::
 
-    You must provide a publicly-accessible file location as the URL for the BIG-IP® VE qcow image. Internally, for testing, we uploaded the zipped image into OpenStack's Swift service and made it publicly accessible.
+    You must provide a publicly-accessible file location as the URL for the BIG-IP VE qcow image. Internally, for testing, we uploaded the zipped image into OpenStack's Swift service and made it publicly accessible.
 
 .. note::
 
@@ -22,5 +22,5 @@ The BIG-IP® VE 'OpenStack-Ready' image template(s) can be used to prepare a BIG
 
 .. warning::
 
-    **Please do not modify the 'user_data' script in the 'onboard_instance' resource**. This script is responsible for making the BIG-IP® VE image OpenStack-ready and any changes made can break the process.
+    **Please do not modify the 'user_data' script in the 'onboard_instance' resource**. This script is responsible for making the BIG-IP VE image OpenStack-ready and any changes made can break the process.
 

--- a/docs/includes/concept_ve-standalone.rst
+++ b/docs/includes/concept_ve-standalone.rst
@@ -2,12 +2,12 @@
 
 .. _ve-standalone:
 
-BIG-IP® VE Standalone Templates
+BIG-IP VE Standalone Templates
 ===============================
 
 Overview
 --------
-The BIG-IP® VE Standalone templates deploy a single VE instance, with variations on the number of desired data interfaces.
+The BIG-IP VE Standalone templates deploy a single VE instance, with variations on the number of desired data interfaces.
 
 
 The standalone templates utilize the same configuration settings as those in the :ref:`Common <ve-common>` directory, such as the security groups and the ``OS::Nova::Server`` resources for VE. Refer to those templates if you'd like to get a better idea of how Heat templates should be composed.

--- a/docs/includes/ref_bigip-security-groups.rst
+++ b/docs/includes/ref_bigip-security-groups.rst
@@ -1,9 +1,9 @@
 :orphan: true
 
-BIG-IP® Security Groups
+BIG-IP Security Groups
 =======================
 
-The following Heat templates can be used to deploy security groups in OpenStack that have the necessary settings to allow traffic to reach your BIG-IP®. These security groups correspond to the control, data, and management networks commonly used with BIG-IP®.
+The following Heat templates can be used to deploy security groups in OpenStack that have the necessary settings to allow traffic to reach your BIG-IP. These security groups correspond to the control, data, and management networks commonly used with BIG-IP.
 
 Control Security Group
 ----------------------
@@ -16,7 +16,7 @@ This security group applies to the 'control' network used for high availability 
 Data Security Group
 -------------------
 
-This security group contains the necessary configurations for passing traffic to BIG-IP® data interfaces (e.g., '1.1', '1.2', '1.3').
+This security group contains the necessary configurations for passing traffic to BIG-IP data interfaces (e.g., '1.1', '1.2', '1.3').
 
 :download:`Download <../../unsupported/ve/common/bigip_data_security_group.yaml>`
 
@@ -24,12 +24,12 @@ This security group contains the necessary configurations for passing traffic to
 Management Security Group
 -------------------------
 
-This security group sets up the necessary configurations to allow incoming and outgoing traffic on the BIG-IP® management interface, which is dedicated to performing a specific set of system management functions.
+This security group sets up the necessary configurations to allow incoming and outgoing traffic on the BIG-IP management interface, which is dedicated to performing a specific set of system management functions.
 
 :download:`Download <../../unsupported/ve/common/bigip_mgmt_security_group.yaml>`
 
 .. seealso::
 
-    * `Introduction to BIG-IP® System Interfaces (v12.0.0) <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-0-0/3.html?sr=54703143>`_
+    * `Introduction to BIG-IP System Interfaces (v12.0.0) <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-0-0/3.html?sr=54703143>`_
 
 

--- a/docs/includes/ref_prerequisites-for-reuse.rst
+++ b/docs/includes/ref_prerequisites-for-reuse.rst
@@ -6,22 +6,22 @@ F5-Supported Heat Template Prerequisites
 .. This file is for internal use only. It contains a list of prerequisites that can be reused in the f5-supported heat template documentation as needed.
 
 
-- Basic understanding of `BIG-IP® system configuration <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-12-0-0/2.html#conceptid>`_.
+- Basic understanding of `BIG-IP system configuration <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-12-0-0/2.html#conceptid>`_.
 
 
-- Basic understanding of `BIG-IP® device service clustering <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-device-service-clustering-admin-12-0-0.html>`_.
+- Basic understanding of `BIG-IP device service clustering <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-device-service-clustering-admin-12-0-0.html>`_.
 
 
-- :ref:`BIG-IP® VE image <F5® BIG-IP® VE: Image Patch & Upload>` uploaded to Glance.
+- :ref:`BIG-IP VE image <F5 BIG-IP VE: Image Patch & Upload>` uploaded to Glance.
 
 
 - :ref:`F5 OpenStack Heat Plugins <heatplugins:home>` installed on the Neutron controller.
 
 
-- :ref:`BIG-IP® Security Groups` configured in OpenStack.
+- :ref:`BIG-IP Security Groups` configured in OpenStack.
 
 
-- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the BIG-IP® VE instances launched by this template.
+- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the BIG-IP VE instances launched by this template.
 
 
 - :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the vm instances launched by this template.
@@ -37,24 +37,24 @@ F5-Supported Heat Template Prerequisites
 
 
 
-- At least two (2) VLANs :ref:`configured in Neutron <docs:os-neutron-network-setup>` -- 'mgmt' and 'data' - to be used for BIG-IP® system management and client-server data traffic, respectively.
+- At least two (2) VLANs :ref:`configured in Neutron <docs:os-neutron-network-setup>` -- 'mgmt' and 'data' - to be used for BIG-IP system management and client-server data traffic, respectively.
 
 
 - An external network with access to the internet.
 
 
-- Two (2) licensed, operational BIG-IP® devices (hardware or Virtual Edition); both must be connected to the 'control' VLAN.
+- Two (2) licensed, operational BIG-IP devices (hardware or Virtual Edition); both must be connected to the 'control' VLAN.
 
-- Login credentials for user(s) with administrative permissions on BIG-IP® device(s).
-
-
-- Licensed, operational BIG-IP® hardware or VE.
+- Login credentials for user(s) with administrative permissions on BIG-IP device(s).
 
 
-- BIG-IP® `License base key <https://support.f5.com/kb/en-us/solutions/public/7000/700/sol7752.html>`_.
+- Licensed, operational BIG-IP hardware or VE.
 
 
-- BIG-IP® LTM® Virtual Edition image file in qcow.zip format; can be any size (ALL, LTM, or LTM_1SLOT). [#]_
+- BIG-IP `License base key <https://support.f5.com/kb/en-us/solutions/public/7000/700/sol7752.html>`_.
+
+
+- BIG-IP LTM Virtual Edition image file in qcow.zip format; can be any size (ALL, LTM, or LTM_1SLOT). [#]_
 
 :rubric: Footnotes:
 .. [#] :ref:`Adding a Ubuntu Image to Glance <add-ubuntu-image-glance>` contains instructions for uploading an image to Glance via the OpenStack dashboard. You may use the OS of your choice; Ubuntu is not a requirement for this template.

--- a/docs/includes/topic_overview-full.rst
+++ b/docs/includes/topic_overview-full.rst
@@ -3,13 +3,13 @@
 Overview
 --------
 
-This guide demonstrates how to use the `OpenStack Heat <https://wiki.openstack.org/wiki/Heat>`_ orchestration service to onboard; deploy; and provision services on an F5® BIG-IP® Virtual Edition (VE) via the `OpenStack dashboard <https://wiki.openstack.org/wiki/Horizon>`_ (aka, the GUI).
+This guide demonstrates how to use the `OpenStack Heat <https://wiki.openstack.org/wiki/Heat>`_ orchestration service to onboard; deploy; and provision services on an F5 BIG-IP Virtual Edition (VE) via the `OpenStack dashboard <https://wiki.openstack.org/wiki/Horizon>`_ (aka, the GUI).
 
 The following :ref:`F5-Supported <f5-supported_home>` Heat templates are used in this guide:
 
-- :file:`patch_upload_ve_image.yaml`: uploads an OpenStack-ready BIG-IP® VE image to Glance.
+- :file:`patch_upload_ve_image.yaml`: uploads an OpenStack-ready BIG-IP VE image to Glance.
 
-- :file:`f5_ve_standalone_3_nic.yaml`: uses the VE image to deploy a standalone BIG-IP® VE.
+- :file:`f5_ve_standalone_3_nic.yaml`: uses the VE image to deploy a standalone BIG-IP VE.
 
 - :file:`deploy-lb`: deploys a simple load balancer on the VE
 

--- a/docs/includes/topic_overview.rst
+++ b/docs/includes/topic_overview.rst
@@ -3,5 +3,5 @@
 Overview
 --------
 
-This guide demonstrates how to use the `OpenStack Heat <https://wiki.openstack.org/wiki/Heat>`_ orchestration service to onboard and deploy F5® BIG-IP® Virtual Edition (VE) in OpenStack.
+This guide demonstrates how to use the `OpenStack Heat <https://wiki.openstack.org/wiki/Heat>`_ orchestration service to onboard and deploy F5 BIG-IP Virtual Edition (VE) in OpenStack.
 

--- a/docs/includes/topic_user-guide-before-you-begin.rst
+++ b/docs/includes/topic_user-guide-before-you-begin.rst
@@ -7,17 +7,17 @@ Before You Begin
 
 You will need the following in order to follow this guide:
 
-- Basic understanding of `BIG-IP® system configuration <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-12-0-0/2.html#conceptid>`_.
+- Basic understanding of `BIG-IP system configuration <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-12-0-0/2.html#conceptid>`_.
 
-- BIG-IP® LTM® Virtual Edition image file in qcow.zip format; can be any size (ALL, LTM, or LTM_1SLOT). [#]_
+- BIG-IP LTM Virtual Edition image file in qcow.zip format; can be any size (ALL, LTM, or LTM_1SLOT). [#]_
 
 - An operational OpenStack |openstack| deployment with `Neutron <http://www.openstack.org/software/releases/kilo/components/neutron>`_ and `Heat <http://www.openstack.org/software/releases/kilo/components/heat>`_ installed. [#]_
 
 - An external network, which has access to the internet, :ref:`configured in Neutron <docs:os-neutron-network-setup>`.
 
-- :ref:`F5 OpenStack Heat Plugins <heatplugins:home>` installed on the Neutron controller. The plugins provide the F5® objects needed to provision BIG-IP® resources in OpenStack.
+- :ref:`F5 OpenStack Heat Plugins <heatplugins:home>` installed on the Neutron controller. The plugins provide the F5 objects needed to provision BIG-IP resources in OpenStack.
 
-- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to BIG-IP® and/or any client or server instances created by the Heat templates.
+- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to BIG-IP and/or any client or server instances created by the Heat templates.
 
 - The Heat templates listed below.
 
@@ -31,9 +31,9 @@ You will need the following in order to follow this guide:
 Caveats
 -------
 
-- The BIG-IP® VE image must be hosted in a location accessible to the Heat engine via 'http'. The F5® Heat templates do not currently support retrieval of files via 'https' or file uploads.
+- The BIG-IP VE image must be hosted in a location accessible to the Heat engine via 'http'. The F5 Heat templates do not currently support retrieval of files via 'https' or file uploads.
 
-- VE images come in 3 different sizes: LTM, ALL, and LTM-1SLOT. Each has its own size requirements, which  determine what Nova flavor you should select. See the F5® OpenStack `BIG-IP® flavor matrix <http://f5-openstack-docs.readthedocs.org/en/latest/guides/openstack_big-ip_flavors.html>`_ for more information.
+- VE images come in 3 different sizes: LTM, ALL, and LTM-1SLOT. Each has its own size requirements, which  determine what Nova flavor you should select. See the F5 OpenStack `BIG-IP flavor matrix <http://f5-openstack-docs.readthedocs.org/en/latest/guides/openstack_big-ip_flavors.html>`_ for more information.
 
 - There is a `known issue <https://bugs.launchpad.net/glance/+bug/1476770>`_ with ``python-glanceclient`` that returns an unspecified error after you click :guilabel:`Launch` to launch a stack from the OpenStack dashboard. You may need to upgrade the package in order to resolve this issue.
 
@@ -41,4 +41,4 @@ Caveats
 .. rubric:: Footnotes:
 
 .. [#] `How to Buy <https://f5.com/products/how-to-buy>`_
-.. [#] Unsure how to get started with OpenStack? See the F5® OpenStack :ref:`deployment <docs:os-deploy-guide>` and :ref:`configuration <docs:os-config-guide>` guides.
+.. [#] Unsure how to get started with OpenStack? See the F5 OpenStack :ref:`deployment <docs:os-deploy-guide>` and :ref:`configuration <docs:os-config-guide>` guides.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,16 +1,16 @@
 .. _home:
 
-F5 Networks® OpenStack Heat Template Library
-############################################
+F5 Networks OpenStack Heat Template Library
+===========================================
 
 .. raw:: html
 
     <script async defer src="https://f5-openstack-slack.herokuapp.com/slackin.js"></script>
 
 Overview
-********
+--------
 
-The F5® OpenStack Heat template library contains templates that can be used to deploy and/or configure BIG-IP® from within an OpenStack cloud.
+The F5 OpenStack Heat template library contains templates that can be used to deploy and/or configure BIG-IP from within an OpenStack cloud.
 
 The library contains two groups of templates:
 
@@ -18,33 +18,33 @@ The library contains two groups of templates:
 * :ref:`Unsupported <unsupported_home>`
 
 Releases and Versions
-*********************
+---------------------
 
 Release |release| supports the OpenStack |openstack| release.
 
 For more information regarding releases and versioning, please see the `Release, Versioning, and Support Matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`_.
 
 Use
-****
+---
 
-Any of F5®'s Heat templates can be downloaded, copied, and/or modified as needed to deploy resources in OpenStack.
+Any of F5's Heat templates can be downloaded, copied, and/or modified as needed to deploy resources in OpenStack.
 
 Heat templates can be loaded via the OpenStack GUI, command line, or API. Please see the `OpenStack Heat documentation <http://docs.openstack.org/developer/heat/#using-heat>`_ for instructions.
 
 .. note::
 
-    Many of the templates require the F5® Heat plugins to be installed.
+    Many of the templates require the F5 Heat plugins to be installed.
     Please see the :ref:`project documentation <heatplugins:home>` for instructions.
 
 
 Support
-*******
+-------
 
 .. include:: ../SUPPORT.md
 
 
 Contents
-********
+--------
 
 .. toctree::
     :maxdepth: 2

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -6,7 +6,7 @@ Release Notes
 Summary
 -------
 
-The current release of the F5® Heat templates, |release|, is compatible with OpenStack |openstack|. See the `F5 OpenStack Releases, Versioning, and Support matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`_ for more information, including BIG-IP® version compatibility.
+The current release of the F5 Heat templates, |release|, is compatible with OpenStack |openstack|. See the `F5 OpenStack Releases, Versioning, and Support matrix <http://f5-openstack-docs.readthedocs.org/en/latest/releases_and_versioning.html>`_ for more information, including BIG-IP version compatibility.
 
 
 Release Highlights

--- a/docs/templates/f5-supported-index.rst
+++ b/docs/templates/f5-supported-index.rst
@@ -7,7 +7,7 @@ F5-Supported Heat Templates
     :start-line: 3
 
 
-The following templates are supported by F5®:
+The following templates are supported by F5:
 
 .. toctree::
     :titlesonly:

--- a/docs/templates/supported/ref_common_f5-ve-standalone-2nic.rst
+++ b/docs/templates/supported/ref_common_f5-ve-standalone-2nic.rst
@@ -1,23 +1,25 @@
-F5® BIG-IP® VE: Standalone, 2-nic
-=================================
+.. _ve2nic:
+
+F5 BIG-IP VE: Standalone, 2-nic
+===============================
 
 Overview
 --------
 
-This template can be used to deploy a standard, standalone F5® BIG-IP® VE in OpenStack. :dfn:`Standalone` refers to a single device that can either function on its own, or be added to a device service group.
+This template can be used to deploy a standard, standalone F5 BIG-IP VE in OpenStack. :dfn:`Standalone` refers to a single device that can either function on its own, or be added to a device service group.
 
 Prerequisites
 -------------
 
 - An external network with access to the internet.
 
-- Basic understanding of `BIG-IP® system configuration <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-12-0-0/2.html#conceptid>`_.
+- Basic understanding of `BIG-IP system configuration <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-12-0-0/2.html#conceptid>`_.
 
 - :ref:`F5 OpenStack Heat Plugins <heatplugins:home>` installed on the Neutron controller.
 
-- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the BIG-IP® VE instances launched by this template.
+- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the BIG-IP VE instances launched by this template.
 
-- :ref:`BIG-IP® VE image <F5® BIG-IP® VE: Image Patch & Upload>` uploaded to Glance.
+- :ref:`BIG-IP VE image <F5 BIG-IP VE: Image Patch & Upload>` uploaded to Glance.
 
 - Two (2) VLANs :ref:`configured in Neutron <docs:os-neutron-network-setup>` -- 'mgmt' and 'data' - to be used for system management and data traffic, respectively.
 
@@ -25,11 +27,11 @@ Prerequisites
 Caveats
 -------
 
-- This template requires internet access; it needs to be able to access GitHub to fetch dependent Heat templates that configure the necessary :ref:`security groups <BIG-IP® Security Groups>`.
+- This template requires internet access; it needs to be able to access GitHub to fetch dependent Heat templates that configure the necessary :ref:`security groups <BIG-IP Security Groups>`.
 
-- This template deploys an unlicensed BIG-IP® VE. You will need to add your `F5 TMOS License Basekey <https://support.f5.com/kb/en-us/solutions/public/7000/700/sol7752.html>`_ manually.
+- This template deploys an unlicensed BIG-IP VE. You will need to add your `F5 TMOS License Basekey <https://support.f5.com/kb/en-us/solutions/public/7000/700/sol7752.html>`_ manually.
 
-- VE images come in 3 different sizes: LTM, ALL, and LTM-1SLOT. Each has its own size requirements, which  determine what Nova flavor you should select. See the F5® OpenStack `BIG-IP® flavor matrix <http://f5-openstack-docs.readthedocs.org/en/latest/guides/openstack_big-ip_flavors.html>`_ for more information.
+- VE images come in 3 different sizes: LTM, ALL, and LTM-1SLOT. Each has its own size requirements, which  determine what Nova flavor you should select. See the F5 OpenStack `BIG-IP flavor matrix <http://f5-openstack-docs.readthedocs.org/en/latest/guides/openstack_big-ip_flavors.html>`_ for more information.
 
 Deployment
 ----------

--- a/docs/templates/supported/ref_common_f5-ve-standalone-3nic.rst
+++ b/docs/templates/supported/ref_common_f5-ve-standalone-3nic.rst
@@ -1,23 +1,25 @@
-F5® BIG-IP® VE: Standalone, 3-nic
-=================================
+.. _ve3nic:
+
+F5 BIG-IP VE: Standalone, 3-nic
+===============================
 
 Overview
 --------
 
-This template can be used to deploy a standard, standalone F5® BIG-IP® VE in OpenStack. :dfn:`Standalone` refers to a single device that can either function on its own, or be added to a device service group.
+This template can be used to deploy a standard, standalone F5 BIG-IP VE in OpenStack. :dfn:`Standalone` refers to a single device that can either function on its own, or be added to a device service group.
 
 Prerequisites
 -------------
 
 - An external network with access to the internet.
 
-- Basic understanding of BIG-IP® `system configuration <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-12-0-0/2.html#conceptid>`_.
+- Basic understanding of BIG-IP `system configuration <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-12-0-0/2.html#conceptid>`_.
 
 - :ref:`F5 OpenStack Heat Plugins <heatplugins:home>` installed on the Neutron controller.
 
-- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the BIG-IP® VE instances launched by this template.
+- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the BIG-IP VE instances launched by this template.
 
-- :ref:`BIG-IP® VE image <F5® BIG-IP® VE: Image Patch & Upload>` uploaded to Glance.
+- :ref:`BIG-IP VE image <F5 BIG-IP VE: Image Patch & Upload>` uploaded to Glance.
 
 - Three (3) VLANs :ref:`configured in Neutron <docs:os-neutron-network-setup>` -- 'mgmt', 'control', and 'data' -- to be used for system management, high availability (if desired), and data traffic, respectively.
 
@@ -25,11 +27,11 @@ Prerequisites
 Caveats
 -------
 
-- This template requires internet access; it needs to be able to access GitHub to fetch dependent Heat templates that configure the necessary :ref:`security groups <BIG-IP® Security Groups>`.
+- This template requires internet access; it needs to be able to access GitHub to fetch dependent Heat templates that configure the necessary :ref:`security groups <BIG-IP Security Groups>`.
 
-- This template deploys an unlicensed BIG-IP® VE. You will need to add your `F5 TMOS License Basekey <https://support.f5.com/kb/en-us/solutions/public/7000/700/sol7752.html>`_ manually.
+- This template deploys an unlicensed BIG-IP VE. You will need to add your `F5 TMOS License Basekey <https://support.f5.com/kb/en-us/solutions/public/7000/700/sol7752.html>`_ manually.
 
-- VE images come in 3 different sizes: LTM, ALL, and LTM-1SLOT. Each has its own size requirements, which  determine what Nova flavor you should select. See the F5® OpenStack `BIG-IP® flavor matrix <http://f5-openstack-docs.readthedocs.org/en/latest/guides/openstack_big-ip_flavors.html>`_ for more information.
+- VE images come in 3 different sizes: LTM, ALL, and LTM-1SLOT. Each has its own size requirements, which  determine what Nova flavor you should select. See the F5 OpenStack `BIG-IP flavor matrix <http://f5-openstack-docs.readthedocs.org/en/latest/guides/openstack_big-ip_flavors.html>`_ for more information.
 
 
 Deployment

--- a/docs/templates/supported/ref_f5-plugins_active-standby.rst
+++ b/docs/templates/supported/ref_f5-plugins_active-standby.rst
@@ -1,28 +1,30 @@
-F5® BIG-IP®: Active-Standby Cluster
-===================================
+.. _active-standby-cluster:
+
+F5 BIG-IP: Active-Standby Cluster
+=================================
 
 Overview
 --------
 
-The active-standby cluster template configures two (2) BIG-IP® devices to function as an 'active-standby pair' in a 'sync-failover device group'. An :dfn:`active-standby pair` is a pair of BIG-IP® devices configured so that one device is actively processing traffic while the other device remains ready to take over if failover occurs. A :dfn:`sync-failover device group` contains devices that synchronize their configuration data and fail over to one another if a device becomes unavailable.
+The active-standby cluster template configures two (2) BIG-IP devices to function as an 'active-standby pair' in a 'sync-failover device group'. An :dfn:`active-standby pair` is a pair of BIG-IP devices configured so that one device is actively processing traffic while the other device remains ready to take over if failover occurs. A :dfn:`sync-failover device group` contains devices that synchronize their configuration data and fail over to one another if a device becomes unavailable.
 
 Prerequisites
 -------------
 
-- Basic understanding of `BIG-IP® device service clustering <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-device-service-clustering-admin-12-0-0.html>`_.
+- Basic understanding of `BIG-IP device service clustering <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-device-service-clustering-admin-12-0-0.html>`_.
 
 - :ref:`F5 OpenStack Heat Plugins <heatplugins:home>` installed on the Neutron controller.
 
 - Three (3) VLANs :ref:`configured in Neutron <docs:os-neutron-network-setup>` -- 'mgmt', 'control', and 'data' -- to be used for system management, high availability, and data traffic, respectively.
 
-- Two (2) licensed, operational BIG-IP® devices (hardware or Virtual Edition); both must be connected to the 'control' VLAN.
+- Two (2) licensed, operational BIG-IP devices (hardware or Virtual Edition); both must be connected to the 'control' VLAN.
 
-- Login credentials for user(s) with administrative permissions on BIG-IP® device(s).
+- Login credentials for user(s) with administrative permissions on BIG-IP device(s).
 
 
 .. seealso::
 
-    * :ref:`F5® BIG-IP® VE: Cluster-Ready, 4-nic` Heat template: deploys a pair of BIG-IP® VE devices that are ready for clustering.
+    * :ref:`F5 BIG-IP VE: Cluster-Ready, 4-nic` Heat template: deploys a pair of BIG-IP VE devices that are ready for clustering.
 
 
 Caveats

--- a/docs/templates/supported/ref_f5plugins_deploy-lb.rst
+++ b/docs/templates/supported/ref_f5plugins_deploy-lb.rst
@@ -1,25 +1,27 @@
+.. _deploy-lb:
+
 Deploy Basic Load Balancer
 ==========================
 
 Overview
 --------
 
-This template deploys a basic load balancing scenario on an F5® BIG-IP® device (hardware or virtual edition). The deployment includes the following resources: one (1) client vm; one (1) server vm; one (1) virtual server, one (1) pool, and one (1) pool member are created on the server vm.
+This template deploys a basic load balancing scenario on an F5 BIG-IP device (hardware or virtual edition). The deployment includes the following resources: one (1) client vm; one (1) server vm; one (1) virtual server, one (1) pool, and one (1) pool member are created on the server vm.
 
 Prerequisites
 -------------
 
-- Licensed, operational BIG-IP® hardware or VE.
+- Licensed, operational BIG-IP hardware or VE.
 
 - Glance image(s) [#]_ for the OS of your choice, to be used for the client and server.
 
-- :ref:`BIG-IP® Security Groups` configured in OpenStack.
+- :ref:`BIG-IP Security Groups` configured in OpenStack.
 
 - :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the vm instances launched by this template.
 
 - :ref:`F5 OpenStack Heat Plugins <heatplugins:home>` installed on the Neutron controller.
 
-- At least two (2) VLANs :ref:`configured in Neutron <docs:os-neutron-network-setup>` -- 'mgmt' and 'data' - to be used for BIG-IP® system management and client-server data traffic, respectively.
+- At least two (2) VLANs :ref:`configured in Neutron <docs:os-neutron-network-setup>` -- 'mgmt' and 'data' - to be used for BIG-IP system management and client-server data traffic, respectively.
 
 
 Caveats

--- a/docs/templates/supported/ref_images_patch-upload-ve-image.rst
+++ b/docs/templates/supported/ref_images_patch-upload-ve-image.rst
@@ -1,10 +1,12 @@
-F5® BIG-IP® VE: Image Patch & Upload
-====================================
+.. _ve-image:
+
+F5 BIG-IP VE: Image Patch & Upload
+==================================
 
 Overview
 --------
 
-This template can be used to prepare a BIG-IP® VE image for use in OpenStack. It launches an Ubuntu server that downloads a zipped F5® BIG-IP® VE qcow image, extracts it, and patches it. The patched image is then uploaded to Glance so it can be used to launch BIG-IP® instances.
+This template can be used to prepare a BIG-IP VE image for use in OpenStack. It launches an Ubuntu server that downloads a zipped F5 BIG-IP VE qcow image, extracts it, and patches it. The patched image is then uploaded to Glance so it can be used to launch BIG-IP instances.
 
 
 Prerequisites
@@ -12,13 +14,13 @@ Prerequisites
 
 - An external network with access to the internet.
 
-- Basic understanding of `BIG-IP® system configuration <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-12-0-0/2.html#conceptid>`_.
+- Basic understanding of `BIG-IP system configuration <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-12-0-0/2.html#conceptid>`_.
 
-- BIG-IP® LTM® Virtual Edition image file in qcow.zip format; can be any size (ALL, LTM, or LTM_1SLOT). [#]_
+- BIG-IP LTM Virtual Edition image file in qcow.zip format; can be any size (ALL, LTM, or LTM_1SLOT). [#]_
 
 - :ref:`F5 OpenStack Heat Plugins <heatplugins:home>` installed on the Neutron controller.
 
-- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the BIG-IP® VE instances launched by this template.
+- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the BIG-IP VE instances launched by this template.
 
 - One (1) VLAN :ref:`configured in Neutron <docs:os-neutron-network-setup>`, to be used by the onboarding server to import the image.
 
@@ -26,9 +28,9 @@ Prerequisites
 Caveats
 -------
 
-- The BIG-IP® image must be hosted in a location accessible to the Heat engine via 'http'. This template does not currently support retrieval of files via 'https' or file uploads.
+- The BIG-IP image must be hosted in a location accessible to the Heat engine via 'http'. This template does not currently support retrieval of files via 'https' or file uploads.
 
-- VE images come in 3 different sizes: LTM, ALL, and LTM-1SLOT. Each has its own size requirements, which  determine what Nova flavor you should select. See the F5® OpenStack `BIG-IP® flavor matrix <http://f5-openstack-docs.readthedocs.org/en/latest/guides/openstack_big-ip_flavors.html>`_ for more information.
+- VE images come in 3 different sizes: LTM, ALL, and LTM-1SLOT. Each has its own size requirements, which  determine what Nova flavor you should select. See the F5 OpenStack `BIG-IP flavor matrix <http://f5-openstack-docs.readthedocs.org/en/latest/guides/openstack_big-ip_flavors.html>`_ for more information.
 
 - There is a `known issue <https://bugs.launchpad.net/glance/+bug/1476770>`_ with ``python-glanceclient`` that returns in an unspecified error after you click :guilabel:`Launch`. You may need to upgrade in order to resolve this issue.
 

--- a/docs/templates/supported/ref_ve_common_cluster-ready-ve-4nic.rst
+++ b/docs/templates/supported/ref_ve_common_cluster-ready-ve-4nic.rst
@@ -1,26 +1,28 @@
-F5® BIG-IP® VE: Cluster-Ready, 4-nic
-====================================
+.. _4nic-cluster-ready
+
+F5 BIG-IP VE: Cluster-Ready, 4-nic
+==================================
 
 Overview
 --------
 
-This template deploys a 'cluster-ready' pair of BIG-IP® VEs. Each device has four (4) network interfaces: management, control, and two (2) data interfaces. The control interface, which is named 'HA', is configured to allow connection failover traffic, configuration synchronization, and connection mirroring. Using a control interface allows for the separation of control traffic from client/user data.
+This template deploys a 'cluster-ready' pair of BIG-IP VEs. Each device has four (4) network interfaces: management, control, and two (2) data interfaces. The control interface, which is named 'HA', is configured to allow connection failover traffic, configuration synchronization, and connection mirroring. Using a control interface allows for the separation of control traffic from client/user data.
 
 
 Prerequisites
 -------------
 
-- Basic understanding of `BIG-IP® device service clustering <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-device-service-clustering-admin-12-0-0.html>`_.
+- Basic understanding of `BIG-IP device service clustering <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-device-service-clustering-admin-12-0-0.html>`_.
 
 - :ref:`F5 OpenStack Heat Plugins <heatplugins:home>` installed on the Neutron controller.
 
-- :ref:`BIG-IP® Security Groups` configured in OpenStack.
+- :ref:`BIG-IP Security Groups` configured in OpenStack.
 
-- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the BIG-IP® VE instances launched by this template.
+- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the BIG-IP VE instances launched by this template.
 
-- :ref:`BIG-IP® VE image <F5® BIG-IP® VE: Image Patch & Upload>` uploaded to Glance.
+- :ref:`BIG-IP VE image <F5 BIG-IP VE: Image Patch & Upload>` uploaded to Glance.
 
-- BIG-IP® `License base key <https://support.f5.com/kb/en-us/solutions/public/7000/700/sol7752.html>`_.
+- BIG-IP `License base key <https://support.f5.com/kb/en-us/solutions/public/7000/700/sol7752.html>`_.
 
 - Three (3) VLANs :ref:`configured in Neutron <docs:os-neutron-network-setup>`-- 'mgmt', 'control', and 'data' -- to be used for system management, high availability, and data traffic, respectively.
 
@@ -28,7 +30,7 @@ Prerequisites
 Caveats
 -------
 
-- VE images come in 3 different sizes: LTM, ALL, and LTM-1SLOT. Each has its own size requirements, which  determine what Nova flavor you should select. See the F5® OpenStack `BIG-IP® flavor matrix <http://f5-openstack-docs.readthedocs.org/en/latest/guides/openstack_big-ip_flavors.html>`_ for more information.
+- VE images come in 3 different sizes: LTM, ALL, and LTM-1SLOT. Each has its own size requirements, which  determine what Nova flavor you should select. See the F5 OpenStack `BIG-IP flavor matrix <http://f5-openstack-docs.readthedocs.org/en/latest/guides/openstack_big-ip_flavors.html>`_ for more information.
 
 Deployment
 ----------

--- a/docs/templates/supported/ref_ve_resourcegroup_f5-two-ve-resource-group.rst
+++ b/docs/templates/supported/ref_ve_resourcegroup_f5-two-ve-resource-group.rst
@@ -1,25 +1,27 @@
-F5® BIG-IP® VE: 2-Device Clustering Prep
-========================================
+.. _cluster-prep:
+
+F5 BIG-IP VE: 2-Device Clustering Prep
+======================================
 
 Overview
 --------
 
-This template deploys two (2) BIG-IP® Virtual Edition (VE) servers in OpenStack and preps them for use in a 'device service cluster'. :dfn:`Device service clustering`, or DSC® , provides synchronization and failover of BIG-IP® configuration data across multiple BIG-IP® devices on a network.
+This template deploys two (2) BIG-IP Virtual Edition (VE) servers in OpenStack and preps them for use in a 'device service cluster'. :dfn:`Device service clustering`, or DSC , provides synchronization and failover of BIG-IP configuration data across multiple BIG-IP devices on a network.
 
 Prerequisites
 -------------
 
-- Basic understanding of BIG-IP® `device service clustering <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-device-service-clustering-admin-12-0-0.html>`_.
+- Basic understanding of BIG-IP `device service clustering <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-device-service-clustering-admin-12-0-0.html>`_.
 
 - :ref:`F5 OpenStack Heat Plugins <heatplugins:home>` installed on the Neutron controller.
 
-- :ref:`BIG-IP® Security Groups` configured in OpenStack.
+- :ref:`BIG-IP Security Groups` configured in OpenStack.
 
-- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the BIG-IP® VE instances launched by this template.
+- :ref:`SSH key(s) <add-ssh-key-horizon>` configured in OpenStack; to be used for authentication to the BIG-IP VE instances launched by this template.
 
-- :ref:`BIG-IP® VE image <F5® BIG-IP® VE: Image Patch & Upload>` uploaded to Glance.
+- :ref:`BIG-IP VE image <F5 BIG-IP VE: Image Patch & Upload>` uploaded to Glance.
 
-- BIG-IP® `License base key <https://support.f5.com/kb/en-us/solutions/public/7000/700/sol7752.html>`_.
+- BIG-IP `License base key <https://support.f5.com/kb/en-us/solutions/public/7000/700/sol7752.html>`_.
 
 - Three (3) VLANs :ref:`configured in Neutron <docs:os-neutron-network-setup>` -- 'mgmt', 'control', and 'data' -- to be used for system management, high availability, and data traffic, respectively.
 
@@ -29,7 +31,7 @@ Prerequisites
 Caveats
 -------
 
-- VE images come in 3 different sizes: LTM, ALL, and LTM-1SLOT. Each has its own size requirements, which  determine what Nova flavor you should select. See the F5® OpenStack `BIG-IP® flavor matrix <http://f5-openstack-docs.readthedocs.org/en/latest/guides/openstack_big-ip_flavors.html>`_ for more information.
+- VE images come in 3 different sizes: LTM, ALL, and LTM-1SLOT. Each has its own size requirements, which  determine what Nova flavor you should select. See the F5 OpenStack `BIG-IP flavor matrix <http://f5-openstack-docs.readthedocs.org/en/latest/guides/openstack_big-ip_flavors.html>`_ for more information.
 
 
 Deployment

--- a/docs/templates/templates_index.rst
+++ b/docs/templates/templates_index.rst
@@ -1,10 +1,10 @@
 Heat Templates
-##############
+==============
 
-F5® provides two categories of Heat templates that can be used to deploy F5® services in Openstack: 'F5-Supported' and 'unsupported'.
+F5 provides two categories of Heat templates that can be used to deploy F5 services in Openstack: 'F5-Supported' and 'unsupported'.
 
 F5-Supported
-************
+------------
 
 .. include:: ../../f5_supported/README.rst
     :start-line: 3
@@ -17,7 +17,7 @@ F5-Supported
 
 
 Unsupported
-***********
+-----------
 
 .. include:: ../../unsupported/README.rst
     :start-line: 3

--- a/docs/templates/unsupported/ref_common_bigip-control-security-group.rst
+++ b/docs/templates/unsupported/ref_common_bigip-control-security-group.rst
@@ -1,5 +1,5 @@
-BIG-IP® Control Security Group
-==============================
+BIG-IP Control Security Group
+=============================
 
 Download the template via the link below, or copy and paste the text into a new file (must be saved as ``.yaml``.
 

--- a/docs/templates/unsupported/ref_common_bigip-data-security-group.rst
+++ b/docs/templates/unsupported/ref_common_bigip-data-security-group.rst
@@ -1,5 +1,5 @@
-BIG-IP® Data Security Group
-===========================
+BIG-IP Data Security Group
+==========================
 
 Download the template via the link below, or copy and paste the text into a new file (must be saved as ``.yaml``.
 

--- a/docs/templates/unsupported/ref_common_bigip-mgmt-security-group.rst
+++ b/docs/templates/unsupported/ref_common_bigip-mgmt-security-group.rst
@@ -1,5 +1,5 @@
-BIG-IP® Management Security Group
-=================================
+BIG-IP Management Security Group
+================================
 
 Download the template via the link below, or copy and paste the text into a new file (must be saved as ``.yaml``.
 


### PR DESCRIPTION
I added section tags to the docs for supported templates and removed the trademark symbols (turns out they're not required for html content).

@pjbreaux 

Fixes #118