### PR TITLE
update branch in deployment to clouddocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ deploy:
   skip_cleanup: true
   on:
     repo: F5Networks/f5-openstack-heat
-    branch: kilo
+    branch: liberty
     condition: $TRAVIS_TAG = ""
   script:
   - ./docs/doc_scripts/deploy-docs.sh publish-product-docs-to-prod templates/openstack-heat $TRAVIS_BRANCH


### PR DESCRIPTION
I have updated the branch from which deployment to clouddocs is allowed from "kilo" to "liberty".