### PR TITLE
Remove references to internal F5 URLs.

### DIFF
--- a/test/functional/ve/images/test_patch_upload_ve_image.py
+++ b/test/functional/ve/images/test_patch_upload_ve_image.py
@@ -65,7 +65,7 @@ def test_patched_image_upload_13_0(
             'f5_image_import_password': symbols.os_password,
             'f5_ve_image_url': symbols.ve_13_0_image_path,
             'f5_ve_image_name': BIGIP_13_0_IMG + '.qcow2',
-            'apt_cache_proxy_url': 'http://apt-cache.pdbld.f5net.com:3142',
+            'apt_cache_proxy_url': 'http://apt-cache.f5.com:3142',
             'f5_image_import_auth_url':
             'http://{}:5000/v2.0'.format(symbols.auth_netloc),
             'os_distro': symbols.os_distro
@@ -93,7 +93,7 @@ def test_patched_image_upload_12_1(
             'f5_image_import_password': symbols.os_password,
             'f5_ve_image_url': symbols.ve_12_1_image_path,
             'f5_ve_image_name': BIGIP_12_1_IMG + '.qcow2',
-            'apt_cache_proxy_url': 'http://apt-cache.pdbld.f5net.com:3142',
+            'apt_cache_proxy_url': 'http://apt-cache.f5.com:3142',
             'f5_image_import_auth_url':
             'http://{}:5000/v2.0'.format(symbols.auth_netloc),
             'os_distro': symbols.os_distro
@@ -120,7 +120,7 @@ def test_patched_image_upload_11_6(
             'private_network': symbols.mgmt_net,
             'f5_image_import_password': symbols.os_password,
             'f5_ve_image_url': symbols.ve_11_6_image_path,
-            'apt_cache_proxy_url': 'http://apt-cache.pdbld.f5net.com:3142',
+            'apt_cache_proxy_url': 'http://apt-cache.f5.com:3142',
             'f5_ve_image_name': BIGIP_11_6_IMG + '.qcow2',
             'f5_image_import_auth_url':
             'http://{}:5000/v2.0'.format(symbols.auth_netloc),
@@ -149,7 +149,7 @@ def test_patched_image_upload_11_5(
             'f5_image_import_password': symbols.os_password,
             'f5_ve_image_url': symbols.ve_11_5_4_image_path,
             'f5_ve_image_name': BIGIP_11_5_4_IMG + '.qcow2',
-            'apt_cache_proxy_url': 'http://apt-cache.pdbld.f5net.com:3142',
+            'apt_cache_proxy_url': 'http://apt-cache.f5.com:3142',
             'f5_image_import_auth_url':
             'http://{}:5000/v2.0'.format(symbols.auth_netloc),
             'os_distro': symbols.os_distro

--- a/unsupported/sp/gi-simplify/gi-simplify-kilo.yaml
+++ b/unsupported/sp/gi-simplify/gi-simplify-kilo.yaml
@@ -101,7 +101,7 @@ parameters:
     cl1_name:
         type: string
         description: The hostname of the first subscriber device
-        default: cl1.os.hype.f5net.com
+        default: cl1.os.hype.f5.com
     cl1_image:
         type: string
         description: Image used by the first subscriber device
@@ -118,7 +118,7 @@ parameters:
     cl2_name:
         type: string
         description: The hostname of the second subscriber device
-        default: cl2.os.hype.f5net.com
+        default: cl2.os.hype.f5.com
     cl2_image:
         type: string
         description: Image used by the second subscriber device
@@ -135,7 +135,7 @@ parameters:
     cl3_name:
         type: string
         description: The hostname of the third subscriber device
-        default: cl3.os.hype.f5net.com
+        default: cl3.os.hype.f5.com
     cl3_image:
         type: string
         description: Image used by the third subscriber device
@@ -152,7 +152,7 @@ parameters:
     cl4_name:
         type: string
         description: The hostname of the fourth subscriber device
-        default: cl4.os.hype.f5net.com
+        default: cl4.os.hype.f5.com
     cl4_image:
         type: string
         description: Image used by the fourth subscriber device
@@ -169,7 +169,7 @@ parameters:
     cpe_name:
         type: string
         description: The hostname of the CPE device
-        default: cpe.os.hype.f5net.com
+        default: cpe.os.hype.f5.com
     cpe_image:
         type: string
         description: Image used by the CPE device
@@ -194,7 +194,7 @@ parameters:
     vas1_name:
         type: string
         description: The hostname of the first VAS device
-        default: vas1.os.hype.f5net.com
+        default: vas1.os.hype.f5.com
     vas1_image:
         type: string
         description: Image used by the first VAS device
@@ -219,7 +219,7 @@ parameters:
     vas2_name:
         type: string
         description: The hostname of the second VAS device
-        default: vas2.os.hype.f5net.com
+        default: vas2.os.hype.f5.com
     vas2_image:
         type: string
         description: Image used by the second VAS device
@@ -244,7 +244,7 @@ parameters:
     vas3_name:
         type: string
         description: The hostname of the third VAS device
-        default: vas3.os.hype.f5net.com
+        default: vas3.os.hype.f5.com
     vas3_image:
         type: string
         description: Image used by the third VAS device
@@ -269,7 +269,7 @@ parameters:
     pe_name:
         type: string
         description: The hostname of the PE device
-        default: pe.os.hype.f5net.com
+        default: pe.os.hype.f5.com
     pe_image:
         type: string
         description: Image used by the PE device
@@ -294,7 +294,7 @@ parameters:
     server_name:
         type: string
         description: The hostname of the server device
-        default: server.os.hype.f5net.com
+        default: server.os.hype.f5.com
     server_image:
         type: string
         description: Image used by the server device
@@ -315,7 +315,7 @@ parameters:
     log_name:
         type: string
         description: The hostname of the logging device
-        default: log.os.hype.f5net.com
+        default: log.os.hype.f5.com
     log_image:
         type: string
         description: Image used by the logging device
@@ -332,7 +332,7 @@ parameters:
     bigip_name:
         type: string
         description: The hostname of the BIG-IP® device
-        default: pem.os.hype.f5net.com
+        default: pem.os.hype.f5.com
     bigip_image:
         type: string
         description: BIG-IP® image used

--- a/unsupported/sp/gi-simplify/gi-simplify-params-boulder.yaml
+++ b/unsupported/sp/gi-simplify/gi-simplify-params-boulder.yaml
@@ -4,73 +4,73 @@ parameters:
     f5_license_key: XXXXX-XXXXX-XXXXX-XXXXX-XXXXXXX
     dns_nameservers: 172.27.1.1,172.27.2.1
 
-    cl1_name: cl1.boulder.os.f5net.com
+    cl1_name: cl1.os.f5.com
     cl1_image: ubuntu-14.04-server-cloudimg-amd64-disk1
     cl1_flavor: m1.small
     cl1_subscriber_ip: 10.0.0.10
 
-    cl2_name: cl2.boulder.os.f5net.com
+    cl2_name: cl2.os.f5.com
     cl2_image: ubuntu-14.04-server-cloudimg-amd64-disk1
     cl2_flavor: m1.small
     cl2_subscriber_ip: 10.0.0.20
 
-    cl3_name: cl3.boulder.os.f5net.com
+    cl3_name: cl3.os.f5.com
     cl3_image: ubuntu-14.04-server-cloudimg-amd64-disk1
     cl3_flavor: m1.small
     cl3_subscriber_ip: 10.0.0.30
 
-    cl4_name: cl4.boulder.os.f5net.com
+    cl4_name: cl4.os.f5.com
     cl4_image: ubuntu-14.04-server-cloudimg-amd64-disk1
     cl4_flavor: m1.small
     cl4_subscriber_ip: 10.0.0.40
 
-    cpe_name: cpe.boulder.os.f5net.com
+    cpe_name: cpe.os.f5.com
     cpe_image: debian-8.2.0-openstack-amd64
     cpe_flavor: m1.small
     cpe_subscriber_ip: 10.0.0.1
     cpe_subs_pem_ip: 10.0.24.1
     cpe_control_ip: 10.0.16.2
 
-    vas1_name: vas1.boulder.os.f5net.com
+    vas1_name: vas1.os.f5.com
     vas1_image: ubuntu-14.04-server-cloudimg-amd64-disk1
     vas1_flavor: m1.small
     vas1_to_vas_ip: 192.168.1.1
     vas1_from_vas_ip: 192.168.2.1
     vas1_control_ip: 10.0.16.200
 
-    vas2_name: vas2.boulder.os.f5net.com
+    vas2_name: vas2.os.f5.com
     vas2_image: ubuntu-14.04-server-cloudimg-amd64-disk1
     vas2_flavor: m1.small
     vas2_to_vas_ip: 192.168.3.1
     vas2_from_vas_ip: 192.168.4.1
     vas2_control_ip: 10.0.16.20
 
-    vas3_name: vas3.boulder.os.f5net.com
+    vas3_name: vas3.os.f5.com
     vas3_image: ubuntu-14.04-server-cloudimg-amd64-disk1
     vas3_flavor: m1.small
     vas3_to_vas_ip: 192.168.5.1
     vas3_from_vas_ip: 192.168.6.1
     vas3_control_ip: 10.0.16.30
 
-    pe_name: pe.boulder.os.f5net.com
+    pe_name: pe.os.f5.com
     pe_image: debian-8.2.0-openstack-amd64
     pe_flavor: m1.small
     pe_internet_pem_ip: 10.0.32.2
     pe_internet_ip: 10.0.8.2
     pe_control_ip: 10.0.16.42
 
-    server_name: server.boulder.os.f5net.com
+    server_name: server.os.f5.com
     server_image: ubuntu-14.04-server-cloudimg-amd64-disk1
     server_flavor: m1.small
     server_internet_ip: 10.0.8.1
     server_control_ip: 10.0.16.77
 
-    log_name: log.boulder.os.f5net.com
+    log_name: log.os.f5.com
     log_image: CentOS-7-x86_64-GenericCloud
     log_flavor: m1.small
     log_control_ip: 10.0.16.66
 
-    bigip_name: pem.boulder.os.f5net.com
+    bigip_name: pem.os.f5.com
     bigip_image: BIGIP-12.0.0.0.0.606-OpenStack
     bigip_flavor: f5.medium
     bigip_control_ip: 10.0.16.1


### PR DESCRIPTION
Problem: Need to remove references to internal F5 URLs.

Analysis: Replace f5net.com references with f5.com.
